### PR TITLE
Gitlab support

### DIFF
--- a/templates/backstage/template.yaml
+++ b/templates/backstage/template.yaml
@@ -116,6 +116,7 @@ spec:
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github
+      action: publish:github
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
       input:
         allowedHosts: ['github.com']
@@ -127,6 +128,7 @@ spec:
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab
       name: Publish Repository to GitLab
+      action: publish:gitlab
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']

--- a/templates/backstage/template.yaml
+++ b/templates/backstage/template.yaml
@@ -114,9 +114,20 @@ spec:
           tags: 'sed.edit.APPTAGS'
           owner: ${{ parameters.owner }} 
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
-    - id: publish
+    - id: publish-github
       name: Publish Repository to Github
-      action: publish:github
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
+      input:
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: ${{ parameters.branch }}
+        protectDefaultBranch: false
+        repoVisibility: "public"
+    # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
+    - id: publish-gitlab
+      name: Publish Repository to GitLab
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
@@ -129,13 +140,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish-github'].output.repoContentsUrl if steps['publish-github'].output else steps['publish-gitlab'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/backstage/template.yaml
+++ b/templates/backstage/template.yaml
@@ -45,7 +45,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              # - gitlab.com can be provided as an option
+              - gitlab.com
         branch:
           title: Repository Default Branch
           type: string

--- a/templates/backstage/template.yaml
+++ b/templates/backstage/template.yaml
@@ -99,7 +99,7 @@ spec:
         values:
           name: ${{ parameters.name }}
           repoUrl: ${{ parameters.repoUrl }}
-          image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
+          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           namespace: ${{ parameters.namespace }}
     - id: fetch-skeleton
       name: Fetch Skeleton

--- a/templates/devfile-sample-code-with-quarkus/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus/template.yaml
@@ -119,9 +119,20 @@ spec:
           tags: '["java", "quarkus", "ssc", "sbom", "acs"]'
           owner: ${{ parameters.owner }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
-    - id: publish
+    - id: publish-github
       name: Publish Repository to Github
-      action: publish:github
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
+      input:
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: ${{ parameters.branch }}
+        protectDefaultBranch: false
+        repoVisibility: "public"
+    # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
+    - id: publish-gitlab
+      name: Publish Repository to GitLab
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
@@ -134,13 +145,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish-github'].output.repoContentsUrl if steps['publish-github'].output else steps['publish-gitlab'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-code-with-quarkus/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus/template.yaml
@@ -121,6 +121,7 @@ spec:
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github
+      action: publish:github
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
       input:
         allowedHosts: ['github.com']
@@ -132,6 +133,7 @@ spec:
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab
       name: Publish Repository to GitLab
+      action: publish:gitlab
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']

--- a/templates/devfile-sample-code-with-quarkus/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus/template.yaml
@@ -51,7 +51,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              # - gitlab.com can be provided as an option
+              - gitlab.com
         branch:
           title: Repository Default Branch
           type: string

--- a/templates/devfile-sample-code-with-quarkus/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus/template.yaml
@@ -104,7 +104,7 @@ spec:
         values:
           name: ${{ parameters.name }}
           repoUrl: ${{ parameters.repoUrl }}
-          image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
+          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           namespace: ${{ parameters.namespace }}
     - id: fetch-skeleton
       name: Fetch Skeleton

--- a/templates/devfile-sample-dotnet60-basic/template.yaml
+++ b/templates/devfile-sample-dotnet60-basic/template.yaml
@@ -118,9 +118,20 @@ spec:
           tags: '["net", "ssc", "sbom", "acs"]'
           owner: ${{ parameters.owner }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
-    - id: publish
+    - id: publish-github
       name: Publish Repository to Github
-      action: publish:github
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
+      input:
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: ${{ parameters.branch }}
+        protectDefaultBranch: false
+        repoVisibility: "public"
+    # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
+    - id: publish-gitlab
+      name: Publish Repository to GitLab
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
@@ -133,13 +144,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish-github'].output.repoContentsUrl if steps['publish-github'].output else steps['publish-gitlab'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-dotnet60-basic/template.yaml
+++ b/templates/devfile-sample-dotnet60-basic/template.yaml
@@ -103,7 +103,7 @@ spec:
         values:
           name: ${{ parameters.name }}
           repoUrl: ${{ parameters.repoUrl }}
-          image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
+          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           namespace: ${{ parameters.namespace }}
     - id: fetch-skeleton
       name: Fetch Skeleton

--- a/templates/devfile-sample-dotnet60-basic/template.yaml
+++ b/templates/devfile-sample-dotnet60-basic/template.yaml
@@ -50,7 +50,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              # - gitlab.com can be provided as an option
+              - gitlab.com
         branch:
           title: Repository Default Branch
           type: string

--- a/templates/devfile-sample-dotnet60-basic/template.yaml
+++ b/templates/devfile-sample-dotnet60-basic/template.yaml
@@ -120,6 +120,7 @@ spec:
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github
+      action: publish:github
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
       input:
         allowedHosts: ['github.com']
@@ -131,6 +132,7 @@ spec:
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab
       name: Publish Repository to GitLab
+      action: publish:gitlab
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -33,8 +33,8 @@ spec:
           title: Owner
           type: string
           description: Owner of the component
-          #default: user:guest
-          ui:field: EntityPicker
+          default: user:guest
+          ui:field: OwnerPicker
           ui:options:
             catalogFilter:
               kind: [Group, User]
@@ -50,7 +50,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              - gitlab.com
+              # - gitlab.com can be provided as an option
         branch:
           title: Repository Default Branch
           type: string
@@ -117,12 +117,10 @@ spec:
           buildContext: .
           tags: '["go", "ssc", "sbom", "acs"]'
           owner: ${{ parameters.owner }}
-    # This action creates a new GitHub/GitLab repository and publishes the files in the workspace directory to the repository.
+    # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github
-      #action: ${{ publish:github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else publish:gitlab }}
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
-      action: publish:github
       input:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
@@ -130,13 +128,12 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+    # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab
-      name: Publish Repository to Gitlab
-      #action: ${{ publish:github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else publish:gitlab }}
+      name: Publish Repository to GitLab
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
-      action: publish:gitlab
       input:
-        allowedHosts:  ['gitlab.com']
+        allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -105,18 +105,18 @@ spec:
           repoUrl: ${{ parameters.repoUrl }}
           image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
           namespace: ${{ parameters.namespace }}
-    # - id: fetch-skeleton
-    #   name: Fetch Skeleton
-    #   action: fetch:template
-    #   input:
-    #     url: ../../skeleton
-    #     values:
-    #       name: ${{ parameters.name }}
-    #       description: Secure Supply Chain Example for Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
-    #       dockerfile: docker/Dockerfile
-    #       buildContext: .
-    #       tags: '["go", "ssc", "sbom", "acs"]'
-    #       owner: ${{ parameters.owner }}
+    - id: fetch-skeleton
+      name: Fetch Skeleton
+      action: fetch:template
+      input:
+        url: ../../skeleton
+        values:
+          name: ${{ parameters.name }}
+          description: Secure Supply Chain Example for Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+          dockerfile: docker/Dockerfile
+          buildContext: .
+          tags: '["go", "ssc", "sbom", "acs"]'
+          owner: ${{ parameters.owner }}
     # This action creates a new GitHub/GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -120,7 +120,7 @@ spec:
     # This action creates a new GitHub/GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish
       name: Publish Repository to Git
-      action: publish:${{ github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else gitlab }}
+      action: publish:'${{ github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else gitlab }}'
       input:
         allowedHosts: [ '${{ (parameters.repoUrl | parseRepoUrl).host }}' ]
         description: This is ${{ parameters.name }}

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -103,7 +103,7 @@ spec:
         values:
           name: ${{ parameters.name }}
           repoUrl: ${{ parameters.repoUrl }}
-          image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
+          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           namespace: ${{ parameters.namespace }}
     - id: fetch-skeleton
       name: Fetch Skeleton

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -50,7 +50,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              # - gitlab.com can be provided as an option
+              - gitlab.com
         branch:
           title: Repository Default Branch
           type: string
@@ -117,12 +117,12 @@ spec:
           buildContext: .
           tags: '["go", "ssc", "sbom", "acs"]'
           owner: ${{ parameters.owner }}
-    # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
+    # This action creates a new GitHub/GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish
-      name: Publish Repository to Github
-      action: publish:github
+      name: Publish Repository to Git
+      action: publish:${{ github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else gitlab }}
       input:
-        allowedHosts: ['github.com']
+        allowedHosts: [${{ (parameters.repoUrl | parseRepoUrl).host }}]
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -33,8 +33,8 @@ spec:
           title: Owner
           type: string
           description: Owner of the component
-          default: user:guest
-          ui:field: OwnerPicker
+          #default: user:guest
+          ui:field: EntityPicker
           ui:options:
             catalogFilter:
               kind: [Group, User]
@@ -105,24 +105,38 @@ spec:
           repoUrl: ${{ parameters.repoUrl }}
           image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
           namespace: ${{ parameters.namespace }}
-    - id: fetch-skeleton
-      name: Fetch Skeleton
-      action: fetch:template
-      input:
-        url: ../../skeleton
-        values:
-          name: ${{ parameters.name }}
-          description: Secure Supply Chain Example for Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
-          dockerfile: docker/Dockerfile
-          buildContext: .
-          tags: '["go", "ssc", "sbom", "acs"]'
-          owner: ${{ parameters.owner }}
+    # - id: fetch-skeleton
+    #   name: Fetch Skeleton
+    #   action: fetch:template
+    #   input:
+    #     url: ../../skeleton
+    #     values:
+    #       name: ${{ parameters.name }}
+    #       description: Secure Supply Chain Example for Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+    #       dockerfile: docker/Dockerfile
+    #       buildContext: .
+    #       tags: '["go", "ssc", "sbom", "acs"]'
+    #       owner: ${{ parameters.owner }}
     # This action creates a new GitHub/GitLab repository and publishes the files in the workspace directory to the repository.
-    - id: publish
-      name: Publish Repository to Git
-      action: publish:'${{ github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else gitlab }}'
+    - id: publish-github
+      name: Publish Repository to Github
+      #action: ${{ publish:github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else publish:gitlab }}
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
+      action: publish:github
       input:
-        allowedHosts: [ '${{ (parameters.repoUrl | parseRepoUrl).host }}' ]
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: ${{ parameters.branch }}
+        protectDefaultBranch: false
+        repoVisibility: "public"
+    - id: publish-gitlab
+      name: Publish Repository to Gitlab
+      #action: ${{ publish:github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else publish:gitlab }}
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
+      action: publish:gitlab
+      input:
+        allowedHosts:  ['gitlab.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: ${{ parameters.branch }}
@@ -133,13 +147,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish-github'].output.repoContentsUrl if steps['publish-github'].output else steps['publish-gitlab'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -50,7 +50,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              # - gitlab.com can be provided as an option
+              - gitlab.com
         branch:
           title: Repository Default Branch
           type: string

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -120,6 +120,7 @@ spec:
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github
+      action: publish:github
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
       input:
         allowedHosts: ['github.com']
@@ -131,6 +132,7 @@ spec:
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab
       name: Publish Repository to GitLab
+      action: publish:gitlab
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -122,7 +122,7 @@ spec:
       name: Publish Repository to Git
       action: publish:${{ github if (parameters.repoUrl | parseRepoUrl).host === 'github.com' else gitlab }}
       input:
-        allowedHosts: [${{ (parameters.repoUrl | parseRepoUrl).host }}]
+        allowedHosts: [ '${{ (parameters.repoUrl | parseRepoUrl).host }}' ]
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-java-springboot-basic/template.yaml
+++ b/templates/devfile-sample-java-springboot-basic/template.yaml
@@ -121,6 +121,7 @@ spec:
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github
+      action: publish:github
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
       input:
         allowedHosts: ['github.com']
@@ -132,6 +133,7 @@ spec:
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab
       name: Publish Repository to GitLab
+      action: publish:gitlab
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']

--- a/templates/devfile-sample-java-springboot-basic/template.yaml
+++ b/templates/devfile-sample-java-springboot-basic/template.yaml
@@ -51,7 +51,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              # - gitlab.com can be provided as an option
+              - gitlab.com
         branch:
           title: Repository Default Branch
           type: string

--- a/templates/devfile-sample-java-springboot-basic/template.yaml
+++ b/templates/devfile-sample-java-springboot-basic/template.yaml
@@ -104,7 +104,7 @@ spec:
         values:
           name: ${{ parameters.name }}
           repoUrl: ${{ parameters.repoUrl }}
-          image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
+          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           namespace: ${{ parameters.namespace }}
     - id: fetch-skeleton
       name: Fetch Skeleton

--- a/templates/devfile-sample-java-springboot-basic/template.yaml
+++ b/templates/devfile-sample-java-springboot-basic/template.yaml
@@ -119,9 +119,20 @@ spec:
           tags: '["java", "spring", "ssc", "sbom", "acs"]'
           owner: ${{ parameters.owner }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
-    - id: publish
+    - id: publish-github
       name: Publish Repository to Github
-      action: publish:github
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
+      input:
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: ${{ parameters.branch }}
+        protectDefaultBranch: false
+        repoVisibility: "public"
+    # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
+    - id: publish-gitlab
+      name: Publish Repository to GitLab
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
@@ -134,13 +145,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish-github'].output.repoContentsUrl if steps['publish-github'].output else steps['publish-gitlab'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-python-basic/template.yaml
+++ b/templates/devfile-sample-python-basic/template.yaml
@@ -122,6 +122,7 @@ spec:
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github
+      action: publish:github
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
       input:
         allowedHosts: ['github.com']
@@ -133,6 +134,7 @@ spec:
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab
       name: Publish Repository to GitLab
+      action: publish:gitlab
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']

--- a/templates/devfile-sample-python-basic/template.yaml
+++ b/templates/devfile-sample-python-basic/template.yaml
@@ -105,7 +105,7 @@ spec:
         values:
           name: ${{ parameters.name }}
           repoUrl: ${{ parameters.repoUrl }}
-          image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
+          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           namespace: ${{ parameters.namespace }}
     - id: fetch-skeleton
       name: Fetch Skeleton

--- a/templates/devfile-sample-python-basic/template.yaml
+++ b/templates/devfile-sample-python-basic/template.yaml
@@ -52,7 +52,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              # - gitlab.com can be provided as an option
+              - gitlab.com
         branch:
           title: Repository Default Branch
           type: string

--- a/templates/devfile-sample-python-basic/template.yaml
+++ b/templates/devfile-sample-python-basic/template.yaml
@@ -120,9 +120,20 @@ spec:
           tags: '["python", "pip", "flask", "ssc", "sbom", "acs"]'
           owner: ${{ parameters.owner }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
-    - id: publish
+    - id: publish-github
       name: Publish Repository to Github
-      action: publish:github
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
+      input:
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: ${{ parameters.branch }}
+        protectDefaultBranch: false
+        repoVisibility: "public"
+    # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
+    - id: publish-gitlab
+      name: Publish Repository to GitLab
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
@@ -135,13 +146,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish-github'].output.repoContentsUrl if steps['publish-github'].output else steps['publish-gitlab'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample/template.yaml
+++ b/templates/devfile-sample/template.yaml
@@ -120,9 +120,20 @@ spec:
           tags: '["nodejs", "express", "ubi8", "ssc", "sbom", "acs"]'
           owner: ${{ parameters.owner }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
-    - id: publish
+    - id: publish-github
       name: Publish Repository to Github
-      action: publish:github
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
+      input:
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: ${{ parameters.branch }}
+        protectDefaultBranch: false
+        repoVisibility: "public"
+    # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
+    - id: publish-gitlab
+      name: Publish Repository to GitLab
+      if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
@@ -135,13 +146,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish-github'].output.repoContentsUrl if steps['publish-github'].output else steps['publish-gitlab'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample/template.yaml
+++ b/templates/devfile-sample/template.yaml
@@ -122,6 +122,7 @@ spec:
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to Github
+      action: publish:github
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'github.com' }}
       input:
         allowedHosts: ['github.com']
@@ -133,6 +134,7 @@ spec:
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab
       name: Publish Repository to GitLab
+      action: publish:gitlab
       if: ${{ (parameters.repoUrl | parseRepoUrl).host === 'gitlab.com' }}
       input:
         allowedHosts: ['github.com']

--- a/templates/devfile-sample/template.yaml
+++ b/templates/devfile-sample/template.yaml
@@ -105,7 +105,7 @@ spec:
         values:
           name: ${{ parameters.name }}
           repoUrl: ${{ parameters.repoUrl }}
-          image: ${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}
+          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           namespace: ${{ parameters.namespace }}
     - id: fetch-skeleton
       name: Fetch Skeleton

--- a/templates/devfile-sample/template.yaml
+++ b/templates/devfile-sample/template.yaml
@@ -52,7 +52,7 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
-              # - gitlab.com can be provided as an option
+              - gitlab.com
         branch:
           title: Repository Default Branch
           type: string


### PR DESCRIPTION
This PR adds gitlab support.
a example of the generated repo: https://gitlab.com/stephanie-cy/goapp1


To test the change, add the following to config:
```
integrations:
  gitlab:
    - host: gitlab.com
      token: <gitlab-token>
catalog:
  locations:
    - type: url
      target: https://github.com/yangcao77/tssc-sample-templates/blob/gitlab-support/all.yaml
      rules:
        - allow: [Location, Template]
```


