### PR TITLE
Add tekton folder to gitops skeleton

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -23,11 +23,14 @@ cp -r $TEMPDIR/$REPONAME/templates/application.yaml $DEST/
 rm -rf $TEMPDIR
 
 # replace {{value}} to ${{ value }} for GPT
+sed -i "s/{{/\${{ /g" $DEST/application.yaml
+sed -i "s/}}/ }}/g" $DEST/application.yaml
+
 function iterate() {
   local dir="$1"
 
   for file in "$dir"/*; do
-    if [ -f "$file" ]  &&  [[ "$file" != *"catalog-info.yaml"* ]]; then
+    if [ -f "$file" ]; then
       sed -i "s/{{/\${{ /g" $file
       sed -i "s/}}/ }}/g" $file
     fi
@@ -38,4 +41,5 @@ function iterate() {
   done
 }
 
-iterate $DEST
+iterate $DEST/components
+

--- a/skeleton/gitops-template/.tekton/gitops-repository.yaml
+++ b/skeleton/gitops-template/.tekton/gitops-repository.yaml
@@ -1,0 +1,6 @@
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: gitops-repository
+spec:
+  url: ${{ values.repoURL }}

--- a/skeleton/gitops-template/.tekton/pull-request.yaml
+++ b/skeleton/gitops-template/.tekton/pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: ${{ values.name }}-on-pull-request
+  namespace: ${{ values.namespace }}
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
+    pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/redhat-appstudio/tssc-sample-pipelines/main/new-for-dance/pipelines-helm/pipeline-promote.yaml"
+    # Todo: pac tasks need to be added after the pipleline has been finalized
+    # pipelinesascode.tekton.dev/task-0: "https://raw.githubusercontent.com/redhat-appstudio/tssc-sample-pipelines/main/pac/tasks/init.yaml"
+    # pipelinesascode.tekton.dev/task-1: "https://raw.githubusercontent.com/redhat-appstudio/tssc-sample-pipelines/main/pac/tasks/git-clone.yaml"
+    # pipelinesascode.tekton.dev/task-2: "https://raw.githubusercontent.com/redhat-appstudio/tssc-sample-pipelines/main/new-for-dance/tasks/task-verify-enterprise-contract.yaml"
+spec: 
+  params:
+  # Todo: params need to be updated after the pipeline has been finalized
+  - name: namespace
+    value: ${{ values.namespace }}
+  - name: gitops-repo-url
+    value: ${{ values.repoURL }}
+  - name: source-repo-url
+    value: ${{ values.srcRepoURL }}
+  - name: component-id
+    value: ${{ values.name }}
+  - name: revision
+    value: '{{revision}}'
+  - name: argocd-host
+    value: argocd.example.com # hardcoded for now
+  pipelineRef:
+    name: ${{ values.appName }}-promote
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate: 
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+ 

--- a/skeleton/gitops-template/.tekton/source-repository.yaml
+++ b/skeleton/gitops-template/.tekton/source-repository.yaml
@@ -1,0 +1,6 @@
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: source-repository
+spec:
+  url: ${{ values.srcRepoURL }}

--- a/templates/backstage/template.yaml
+++ b/templates/backstage/template.yaml
@@ -198,6 +198,9 @@ spec:
         url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: GitOps Repository
         url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-      - title: Open in catalog
+      - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}
+      - title: Open GitOps Resource in catalog
+        icon: catalog
+        entityRef: ${{ steps['register-gitops'].output.entityRef }}

--- a/templates/backstage/template.yaml
+++ b/templates/backstage/template.yaml
@@ -155,6 +155,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
+          srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           # TODO - change this to the application root when multicomponents are created
           #argoComponent: './components/${{ parameters.name }}'
           argoComponent: './components/http/overlays/development'

--- a/templates/devfile-sample-code-with-quarkus/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus/template.yaml
@@ -160,6 +160,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
+          srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           # TODO - change this to the application root when multicomponents are created
           #argoComponent: './components/${{ parameters.name }}'
           argoComponent: './components/http/overlays/development'
@@ -203,6 +204,9 @@ spec:
         url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: GitOps Repository
         url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-      - title: Open in catalog
+      - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}
+      - title: Open GitOps Resource in catalog
+        icon: catalog
+        entityRef: ${{ steps['register-gitops'].output.entityRef }}

--- a/templates/devfile-sample-dotnet60-basic/template.yaml
+++ b/templates/devfile-sample-dotnet60-basic/template.yaml
@@ -159,6 +159,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
+          srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           # TODO - change this to the application root when multicomponents are created
           #argoComponent: './components/${{ parameters.name }}'
           argoComponent: './components/http/overlays/development'
@@ -202,6 +203,9 @@ spec:
         url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: GitOps Repository
         url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-      - title: Open in catalog
+      - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}
+      - title: Open GitOps Resource in catalog
+        icon: catalog
+        entityRef: ${{ steps['register-gitops'].output.entityRef }}

--- a/templates/devfile-sample-go-basic/template.yaml
+++ b/templates/devfile-sample-go-basic/template.yaml
@@ -159,6 +159,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
+          srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           # TODO - change this to the application root when multicomponents are created
           #argoComponent: './components/${{ parameters.name }}'
           argoComponent: './components/http/overlays/development'
@@ -202,6 +203,9 @@ spec:
         url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: GitOps Repository
         url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-      - title: Open in catalog
+      - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}
+      - title: Open GitOps Resource in catalog
+        icon: catalog
+        entityRef: ${{ steps['register-gitops'].output.entityRef }}

--- a/templates/devfile-sample-java-springboot-basic/template.yaml
+++ b/templates/devfile-sample-java-springboot-basic/template.yaml
@@ -160,6 +160,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
+          srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           # TODO - change this to the application root when multicomponents are created
           #argoComponent: './components/${{ parameters.name }}'
           argoComponent: './components/http/overlays/development'
@@ -203,6 +204,9 @@ spec:
         url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: GitOps Repository
         url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-      - title: Open in catalog
+      - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}
+      - title: Open GitOps Resource in catalog
+        icon: catalog
+        entityRef: ${{ steps['register-gitops'].output.entityRef }}

--- a/templates/devfile-sample-python-basic/template.yaml
+++ b/templates/devfile-sample-python-basic/template.yaml
@@ -161,6 +161,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
+          srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           # TODO - change this to the application root when multicomponents are created
           #argoComponent: './components/${{ parameters.name }}'
           argoComponent: './components/http/overlays/development'
@@ -204,6 +205,9 @@ spec:
         url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: GitOps Repository
         url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-      - title: Open in catalog
+      - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}
+      - title: Open GitOps Resource in catalog
+        icon: catalog
+        entityRef: ${{ steps['register-gitops'].output.entityRef }}

--- a/templates/devfile-sample/template.yaml
+++ b/templates/devfile-sample/template.yaml
@@ -161,6 +161,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
+          srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           # TODO - change this to the application root when multicomponents are created
           #argoComponent: './components/${{ parameters.name }}'
           argoComponent: './components/http/overlays/development'
@@ -204,6 +205,9 @@ spec:
         url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else steps['publish-gitlab'].output.remoteUrl }}
       - title: GitOps Repository
         url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-      - title: Open in catalog
+      - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}
+      - title: Open GitOps Resource in catalog
+        icon: catalog
+        entityRef: ${{ steps['register-gitops'].output.entityRef }}


### PR DESCRIPTION
The PR adds the tekton folder with source and gitops Repository CRs as well as the PR PipelineRun. 

The PR PipelineRun still need to be updated once the promote pipeline definition has been finalized. Currently is just for showcase purpose. 

example generated gitops repo tekton folder: https://github.com/stephanie-cy/go-app2-gitops/tree/main/.tekton