### PR TITLE
add tekton resources to the gitops overlay

### DIFF
--- a/skeleton/gitops-template/components/http/overlays/development/gitops-repository.yaml
+++ b/skeleton/gitops-template/components/http/overlays/development/gitops-repository.yaml
@@ -1,0 +1,6 @@
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: gitops-repository
+spec:
+  url: $${{  values.repoURL  }}

--- a/skeleton/gitops-template/components/http/overlays/development/kustomization.yaml
+++ b/skeleton/gitops-template/components/http/overlays/development/kustomization.yaml
@@ -3,4 +3,6 @@ kind: Kustomization
 patchesStrategicMerge:
 - deployment-patch.yaml
 resources:
-- ../../base
+- ../../base 
+- gitops-repository.yaml
+- source-repository.yaml

--- a/skeleton/gitops-template/components/http/overlays/development/source-repository.yaml
+++ b/skeleton/gitops-template/components/http/overlays/development/source-repository.yaml
@@ -1,0 +1,6 @@
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: source-repository
+spec:
+  url: $${{  values.srcRepoURL  }}


### PR DESCRIPTION
The tekton repository CRs were not being installed.
Moved them to the dev overlay and included in kustomize
The originals are left (for now). Quick fix