### PR TITLE
pull in latest gitops template for the port change

### DIFF
--- a/skeleton/gitops-template/components/http/base/deployment.yaml
+++ b/skeleton/gitops-template/components/http/base/deployment.yaml
@@ -29,17 +29,17 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: 8080
+            port: ${{ values.port }} 
           initialDelaySeconds: 10
           periodSeconds: 10
         name: container-image
         ports:
-        - containerPort: 8080
+        - containerPort: ${{ values.port }} 
         readinessProbe:
           initialDelaySeconds: 10
           periodSeconds: 10
           tcpSocket:
-            port: 8080
+            port: ${{ values.port }} 
         resources:
           limits:
             cpu: "1"

--- a/skeleton/gitops-template/components/http/base/route.yaml
+++ b/skeleton/gitops-template/components/http/base/route.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: ${{ values.namespace }}
 spec:
   port:
-    targetPort: 8080
+    targetPort: ${{ values.port }} 
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge

--- a/skeleton/gitops-template/components/http/base/service.yaml
+++ b/skeleton/gitops-template/components/http/base/service.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: ${{ values.namespace }}
 spec:
   ports:
-  - port: 8080
-    targetPort: 8080
+  - port: ${{ values.port }} 
+    targetPort: ${{ values.port }} 
   selector:
     app.kubernetes.io/instance: ${{ values.name }} 


### PR DESCRIPTION
This PR pull in latest gitops template change to be able to substitute port number in generated gitops repo. 

Tested, the genetrated gitops repo is with the expected port `8081`:
https://github.com/stephanie-cy/go-app1-gitops/blob/main/components/go-app1/base/service.yaml