### PR TITLE
Update GPT template to use bootstrap app for deployment image

### DIFF
--- a/templates/backstage/template.yaml
+++ b/templates/backstage/template.yaml
@@ -159,7 +159,9 @@ spec:
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           owner: ${{ parameters.owner }} 
-          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
+          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
+          srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: sed.edit.IMAGEPORT
     - action: fs:rename
       id: renameComponentDir
@@ -200,6 +202,16 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
+    - id: create-argocd-resources
+      name: Create ArgoCD Resources
+      action: argocd:create-resources
+      input:
+        appName: ${{ parameters.name }}-gitops
+        # name set in rhdh config
+        argoInstance: default
+        namespace: ${{ parameters.namespace}}
+        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
+        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/backstage/template.yaml
+++ b/templates/backstage/template.yaml
@@ -202,16 +202,6 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
-    - id: create-argocd-resources
-      name: Create ArgoCD Resources
-      action: argocd:create-resources
-      input:
-        appName: ${{ parameters.name }}-gitops
-        # name set in rhdh config
-        argoInstance: default
-        namespace: ${{ parameters.namespace}}
-        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -202,16 +202,6 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
-    - id: create-argocd-resources
-      name: Create ArgoCD Resources
-      action: argocd:create-resources
-      input:
-        appName: ${{ parameters.name }}-gitops
-        # name set in rhdh config
-        argoInstance: default
-        namespace: ${{ parameters.namespace}}
-        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -159,7 +159,9 @@ spec:
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           owner: ${{ parameters.owner }} 
-          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
+          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
+          srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
     - action: fs:rename
       id: renameComponentDir
@@ -200,6 +202,16 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
+    - id: create-argocd-resources
+      name: Create ArgoCD Resources
+      action: argocd:create-resources
+      input:
+        appName: ${{ parameters.name }}-gitops
+        # name set in rhdh config
+        argoInstance: default
+        namespace: ${{ parameters.namespace}}
+        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
+        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -202,16 +202,6 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
-    - id: create-argocd-resources
-      name: Create ArgoCD Resources
-      action: argocd:create-resources
-      input:
-        appName: ${{ parameters.name }}-gitops
-        # name set in rhdh config
-        argoInstance: default
-        namespace: ${{ parameters.namespace}}
-        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -159,7 +159,9 @@ spec:
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           owner: ${{ parameters.owner }} 
-          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
+          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
+          srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
     - action: fs:rename
       id: renameComponentDir
@@ -200,6 +202,16 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
+    - id: create-argocd-resources
+      name: Create ArgoCD Resources
+      action: argocd:create-resources
+      input:
+        appName: ${{ parameters.name }}-gitops
+        # name set in rhdh config
+        argoInstance: default
+        namespace: ${{ parameters.namespace}}
+        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
+        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -202,16 +202,6 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
-    - id: create-argocd-resources
-      name: Create ArgoCD Resources
-      action: argocd:create-resources
-      input:
-        appName: ${{ parameters.name }}-gitops
-        # name set in rhdh config
-        argoInstance: default
-        namespace: ${{ parameters.namespace}}
-        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -159,7 +159,9 @@ spec:
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           owner: ${{ parameters.owner }} 
-          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
+          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
+          srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
     - action: fs:rename
       id: renameComponentDir
@@ -200,6 +202,16 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
+    - id: create-argocd-resources
+      name: Create ArgoCD Resources
+      action: argocd:create-resources
+      input:
+        appName: ${{ parameters.name }}-gitops
+        # name set in rhdh config
+        argoInstance: default
+        namespace: ${{ parameters.namespace}}
+        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
+        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -202,16 +202,6 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
-    - id: create-argocd-resources
-      name: Create ArgoCD Resources
-      action: argocd:create-resources
-      input:
-        appName: ${{ parameters.name }}-gitops
-        # name set in rhdh config
-        argoInstance: default
-        namespace: ${{ parameters.namespace}}
-        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -159,7 +159,9 @@ spec:
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           owner: ${{ parameters.owner }} 
-          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
+          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
+          srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
     - action: fs:rename
       id: renameComponentDir
@@ -200,6 +202,16 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
+    - id: create-argocd-resources
+      name: Create ArgoCD Resources
+      action: argocd:create-resources
+      input:
+        appName: ${{ parameters.name }}-gitops
+        # name set in rhdh config
+        argoInstance: default
+        namespace: ${{ parameters.namespace}}
+        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
+        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -202,16 +202,6 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
-    - id: create-argocd-resources
-      name: Create ArgoCD Resources
-      action: argocd:create-resources
-      input:
-        appName: ${{ parameters.name }}-gitops
-        # name set in rhdh config
-        argoInstance: default
-        namespace: ${{ parameters.namespace}}
-        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -159,7 +159,9 @@ spec:
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           owner: ${{ parameters.owner }} 
-          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
+          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
+          srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 3001
     - action: fs:rename
       id: renameComponentDir
@@ -200,6 +202,16 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
+    - id: create-argocd-resources
+      name: Create ArgoCD Resources
+      action: argocd:create-resources
+      input:
+        appName: ${{ parameters.name }}-gitops
+        # name set in rhdh config
+        argoInstance: default
+        namespace: ${{ parameters.namespace}}
+        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
+        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -202,16 +202,6 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
-    - id: create-argocd-resources
-      name: Create ArgoCD Resources
-      action: argocd:create-resources
-      input:
-        appName: ${{ parameters.name }}-gitops
-        # name set in rhdh config
-        argoInstance: default
-        namespace: ${{ parameters.namespace}}
-        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
-        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -159,7 +159,9 @@ spec:
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           owner: ${{ parameters.owner }} 
-          image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
+          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
+          srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
     - action: fs:rename
       id: renameComponentDir
@@ -200,6 +202,16 @@ spec:
       input:
         repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
+    - id: create-argocd-resources
+      name: Create ArgoCD Resources
+      action: argocd:create-resources
+      input:
+        appName: ${{ parameters.name }}-gitops
+        # name set in rhdh config
+        argoInstance: default
+        namespace: ${{ parameters.namespace}}
+        repoUrl: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else steps['publish-gitlab-gitops'].output.remoteUrl }}
+        path: ./
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:


### PR DESCRIPTION
This PR updates the GPT template to use bootstrap app `quay.io/redhat-appstudio/dance-bootstrap-app:latest` for gitops app deployment. 

the actual image is passed in as `values.srcImage` will be accessable by the PR tekton pipeline once it's been finalized. 