### PR TITLE
update repo CRs to have it's unique name

### DIFF
--- a/skeleton/gitops-template/.tekton/gitops-repository.yaml
+++ b/skeleton/gitops-template/.tekton/gitops-repository.yaml
@@ -1,6 +1,6 @@
 apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
 kind: Repository
 metadata:
-  name: gitops-repository
+  name: ${{ values.appName }}-repository
 spec:
   url: ${{ values.repoURL }}

--- a/skeleton/gitops-template/.tekton/source-repository.yaml
+++ b/skeleton/gitops-template/.tekton/source-repository.yaml
@@ -1,6 +1,6 @@
 apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
 kind: Repository
 metadata:
-  name: source-repository
+  name: ${{ values.name }}-repository
 spec:
   url: ${{ values.srcRepoURL }}

--- a/skeleton/gitops-template/components/http/overlays/development/gitops-repository.yaml
+++ b/skeleton/gitops-template/components/http/overlays/development/gitops-repository.yaml
@@ -1,6 +1,6 @@
 apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
 kind: Repository
 metadata:
-  name: gitops-repository
+  name: ${{ values.appName }}-repository
 spec:
   url: ${{ values.repoURL }}

--- a/skeleton/gitops-template/components/http/overlays/development/source-repository.yaml
+++ b/skeleton/gitops-template/components/http/overlays/development/source-repository.yaml
@@ -1,6 +1,6 @@
 apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
 kind: Repository
 metadata:
-  name: source-repository
+  name: ${{ values.name }}-repository
 spec:
   url: ${{ values.srcRepoURL }}


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/RHTAPBUGS-1136

This PR allows the repo CRs to have it's unique name for each component's source repo and gitops repo. 

tested: 
https://github.com/stephanie-cy/sssad-gitops/blob/58e67668d35cbf3a6f0acf2370d534d847b80d80/components/ss/overlays/development/gitops-repository.yaml#L4

https://github.com/stephanie-cy/sssad-gitops/blob/58e67668d35cbf3a6f0acf2370d534d847b80d80/components/ss/overlays/development/source-repository.yaml#L4