### PR TITLE
App of Apps for three environments

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -19,8 +19,11 @@ git clone $REPO 2>&1 > /dev/null
 
 DEST=$ROOTDIR/skeleton/gitops-template
 rm -rf $DEST/components
+rm -rf $DEST/app-of-apps
 rm -rf $DEST/application.yaml
 mkdir -p $DEST/components
+mkdir -p $DEST/app-of-apps
+cp -r $TEMPDIR/$REPONAME/templates/app-of-apps $DEST/
 cp -r $TEMPDIR/$REPONAME/templates/http $DEST/components/http     # only support http now
 cp -r $TEMPDIR/$REPONAME/templates/application.yaml $DEST/
 rm -rf $TEMPDIR
@@ -45,6 +48,7 @@ function iterate() {
 }
 
 iterate $DEST/components
+iterate $DEST/app-of-apps
 
 
 cp -r  $DEST/.tekton/*-repository.yaml $DEST/components/http/overlays/development    # temporary workaround for gitops

--- a/scripts/update-tekton-definition
+++ b/scripts/update-tekton-definition
@@ -10,10 +10,12 @@ mkdir -p $TEMPDIR
 cd $TEMPDIR
 git clone $REPO 2>&1 > /dev/null
 
-DEST=$ROOTDIR/skeleton/source-repo/.tekton
+DEST=$ROOTDIR/skeleton/source-repo/.tekton 
+rm -rf $DEST
+mkdir -p $DEST
 
 cd $TEMPDIR/$REPONAME
-cp -r $TEMPDIR/$REPONAME/pac/docker-build-rhtap/ $DEST
+cp -r $TEMPDIR/$REPONAME/pac/docker-build-rhtap/. $DEST
 rm -rf $TEMPDIR
 
 

--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -144,6 +144,7 @@ spec:
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
+          argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
@@ -203,12 +204,12 @@ spec:
       name: Create ArgoCD Resources
       action: argocd:create-resources
       input:
-        appName: ${{ parameters.name }}
+        appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: ${{ parameters.namespace}}
+        namespace: openshift-gitops 
         repoUrl: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops.git
-        path: './components/${{ parameters.name }}/overlays/development'
+        path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/skeleton/gitops-template/app-of-apps/application-dev.yaml
+++ b/skeleton/gitops-template/app-of-apps/application-dev.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.name }}-development
+  namespace: openshift-gitops 
+  finalizers: ["resources-finalizer.argocd.argoproj.io"] 
+spec:
+  project: default
+  source:
+    path: ${{ values.argoComponentOverlays }}/development
+    repoURL: ${{ values.repoURL }}
+    targetRevision: main
+  destination:
+    namespace: ${{ values.namespace }}-development
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels: 
+        argocd.argoproj.io/managed-by: openshift-gitops
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true

--- a/skeleton/gitops-template/app-of-apps/application-prod.yaml
+++ b/skeleton/gitops-template/app-of-apps/application-prod.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.name }}-prod
+  namespace: openshift-gitops 
+  finalizers: ["resources-finalizer.argocd.argoproj.io"] 
+spec:
+  project: default
+  source:
+    path: ${{ values.argoComponentOverlays }}/prod
+    repoURL: ${{ values.repoURL }}
+    targetRevision: main
+  destination:
+    namespace: ${{ values.namespace }}-prod
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels: 
+        argocd.argoproj.io/managed-by: openshift-gitops
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true

--- a/skeleton/gitops-template/app-of-apps/application-stage.yaml
+++ b/skeleton/gitops-template/app-of-apps/application-stage.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.name }}-stage
+  namespace: openshift-gitops 
+  finalizers: ["resources-finalizer.argocd.argoproj.io"] 
+spec:
+  project: default
+  source:
+    path: ${{ values.argoComponentOverlays }}/stage
+    repoURL: ${{ values.repoURL }}
+    targetRevision: main
+  destination:
+    namespace: ${{ values.namespace }}-stage
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels: 
+        argocd.argoproj.io/managed-by: openshift-gitops
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+

--- a/skeleton/gitops-template/app-of-apps/kustomization.yaml
+++ b/skeleton/gitops-template/app-of-apps/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:         
+  rhtap/gitops: ${{  values.name  }} 
+  janus-idp.io/tekton: ${{  values.name  }}
+  backstage.io/kubernetes-id: ${{  values.name  }}
+  backstage.io/kubernetes-namespace: ${{  values.namespace  }} 
+  app.kubernetes.io/part-of: ${{  values.name  }}
+resources: 
+- application-dev.yaml 
+- application-stage.yaml 
+- application-prod.yaml  

--- a/skeleton/gitops-template/catalog-info.yaml
+++ b/skeleton/gitops-template/catalog-info.yaml
@@ -11,8 +11,7 @@ metadata:
   annotations:    
     argocd/app-name: ${{ values.name }}
     janus-idp.io/tekton: ${{ values.name }} 
-    backstage.io/kubernetes-id: ${{ values.name }}
-    backstage.io/kubernetes-namespace: ${{ values.namespace }}
+    backstage.io/kubernetes-id: ${{ values.name }} 
     backstage.io/techdocs-ref: dir:. 
 spec:
   type: gitops

--- a/skeleton/gitops-template/components/http/overlays/prod/deployment-patch.yaml
+++ b/skeleton/gitops-template/components/http/overlays/prod/deployment-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:   
+  annotations:  
+    tad.gitops.set/image: ".spec.template.spec.containers[0].image"
+    tad.gitops.get/image: ".spec.template.spec.containers[0].image"
+    tad.gitops.set/replicas: ".spec.replicas"
+    tad.gitops.get/replicas: ".spec.replicas" 
+  name: ${{ values.name }}
+spec:
+  replicas: 1 
+  template: 
+    spec:
+      containers:
+      - image: ${{ values.image }}
+        name: container-image  

--- a/skeleton/gitops-template/components/http/overlays/prod/kustomization.yaml
+++ b/skeleton/gitops-template/components/http/overlays/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+- deployment-patch.yaml
+resources:
+- ../../base  

--- a/skeleton/gitops-template/components/http/overlays/stage/deployment-patch.yaml
+++ b/skeleton/gitops-template/components/http/overlays/stage/deployment-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:   
+  annotations:  
+    tad.gitops.set/image: ".spec.template.spec.containers[0].image"
+    tad.gitops.get/image: ".spec.template.spec.containers[0].image"
+    tad.gitops.set/replicas: ".spec.replicas"
+    tad.gitops.get/replicas: ".spec.replicas" 
+  name: ${{ values.name }}
+spec:
+  replicas: 1 
+  template: 
+    spec:
+      containers:
+      - image: ${{ values.image }}
+        name: container-image  

--- a/skeleton/gitops-template/components/http/overlays/stage/kustomization.yaml
+++ b/skeleton/gitops-template/components/http/overlays/stage/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+- deployment-patch.yaml
+resources:
+- ../../base  

--- a/skeleton/source-repo/.tekton/README.md
+++ b/skeleton/source-repo/.tekton/README.md
@@ -1,12 +1,19 @@
-# docker-build-shared with shared pipeline references 
+# docker-build-rhtap
+
+## Shared Git resolver model for shared pipeline and tasks. 
  
-This component pipeline is used to create dockerfile builds. 
-The task references come from [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repository , `pipelines` `tasks` and are referenced by URL 
+This pipeline is used to create dockerfile based sscs builds. 
+Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
  `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
+   
+
+## Templates 
+These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
+

--- a/skeleton/source-repo/.tekton/docker-pull-request.yaml
+++ b/skeleton/source-repo/.tekton/docker-pull-request.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: ${{ values.name }}-on-pull-request
-  namespace: ${{ values.namespace }}
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"

--- a/skeleton/source-repo/.tekton/docker-push.yaml
+++ b/skeleton/source-repo/.tekton/docker-push.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: ${{ values.name }}-on-push
-  namespace: ${{ values.namespace }}
   annotations:
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"

--- a/skeleton/source-repo/catalog-info.yaml
+++ b/skeleton/source-repo/catalog-info.yaml
@@ -9,10 +9,10 @@ metadata:
       icon: dashboard
       type: admin-dashboard
   annotations:
-    argocd/app-name: ${{ values.name }}
+    # ArgoCD apps from this template used rhtap-gitops as the grouping
+    argocd/app-selector: rhtap/gitops=${{  values.name  }}  
     janus-idp.io/tekton: ${{ values.name }} 
-    backstage.io/kubernetes-id: ${{ values.name }}
-    backstage.io/kubernetes-namespace: ${{ values.namespace }}
+    backstage.io/kubernetes-id: ${{ values.name }} 
     backstage.io/techdocs-ref: dir:. 
   tags: ${{ values.tags }} 
 spec:

--- a/templates/devfile-sample-code-with-quarkus-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-code-with-quarkus-dance/content/docs/pipelines.md
@@ -1,12 +1,19 @@
-# docker-build-shared with shared pipeline references 
+# docker-build-rhtap
+
+## Shared Git resolver model for shared pipeline and tasks. 
  
-This component pipeline is used to create dockerfile builds. 
-The task references come from [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repository , `pipelines` `tasks` and are referenced by URL 
+This pipeline is used to create dockerfile based sscs builds. 
+Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
  `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
+   
+
+## Templates 
+These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
+

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -144,6 +144,7 @@ spec:
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
+          argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
@@ -203,12 +204,12 @@ spec:
       name: Create ArgoCD Resources
       action: argocd:create-resources
       input:
-        appName: ${{ parameters.name }}
+        appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: ${{ parameters.namespace}}
+        namespace: openshift-gitops 
         repoUrl: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops.git
-        path: './components/${{ parameters.name }}/overlays/development'
+        path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-dotnet60-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-dotnet60-dance/content/docs/pipelines.md
@@ -1,12 +1,19 @@
-# docker-build-shared with shared pipeline references 
+# docker-build-rhtap
+
+## Shared Git resolver model for shared pipeline and tasks. 
  
-This component pipeline is used to create dockerfile builds. 
-The task references come from [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repository , `pipelines` `tasks` and are referenced by URL 
+This pipeline is used to create dockerfile based sscs builds. 
+Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
  `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
+   
+
+## Templates 
+These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
+

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -144,6 +144,7 @@ spec:
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
+          argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
@@ -203,12 +204,12 @@ spec:
       name: Create ArgoCD Resources
       action: argocd:create-resources
       input:
-        appName: ${{ parameters.name }}
+        appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: ${{ parameters.namespace}}
+        namespace: openshift-gitops 
         repoUrl: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops.git
-        path: './components/${{ parameters.name }}/overlays/development'
+        path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-go-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-go-dance/content/docs/pipelines.md
@@ -1,12 +1,19 @@
-# docker-build-shared with shared pipeline references 
+# docker-build-rhtap
+
+## Shared Git resolver model for shared pipeline and tasks. 
  
-This component pipeline is used to create dockerfile builds. 
-The task references come from [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repository , `pipelines` `tasks` and are referenced by URL 
+This pipeline is used to create dockerfile based sscs builds. 
+Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
  `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
+   
+
+## Templates 
+These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
+

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -144,6 +144,7 @@ spec:
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
+          argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
@@ -203,12 +204,12 @@ spec:
       name: Create ArgoCD Resources
       action: argocd:create-resources
       input:
-        appName: ${{ parameters.name }}
+        appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: ${{ parameters.namespace}}
+        namespace: openshift-gitops 
         repoUrl: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops.git
-        path: './components/${{ parameters.name }}/overlays/development'
+        path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-java-springboot-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-java-springboot-dance/content/docs/pipelines.md
@@ -1,12 +1,19 @@
-# docker-build-shared with shared pipeline references 
+# docker-build-rhtap
+
+## Shared Git resolver model for shared pipeline and tasks. 
  
-This component pipeline is used to create dockerfile builds. 
-The task references come from [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repository , `pipelines` `tasks` and are referenced by URL 
+This pipeline is used to create dockerfile based sscs builds. 
+Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
  `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
+   
+
+## Templates 
+These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
+

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -144,6 +144,7 @@ spec:
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
+          argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
@@ -203,12 +204,12 @@ spec:
       name: Create ArgoCD Resources
       action: argocd:create-resources
       input:
-        appName: ${{ parameters.name }}
+        appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: ${{ parameters.namespace}}
+        namespace: openshift-gitops 
         repoUrl: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops.git
-        path: './components/${{ parameters.name }}/overlays/development'
+        path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-nodejs-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-nodejs-dance/content/docs/pipelines.md
@@ -1,12 +1,19 @@
-# docker-build-shared with shared pipeline references 
+# docker-build-rhtap
+
+## Shared Git resolver model for shared pipeline and tasks. 
  
-This component pipeline is used to create dockerfile builds. 
-The task references come from [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repository , `pipelines` `tasks` and are referenced by URL 
+This pipeline is used to create dockerfile based sscs builds. 
+Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
  `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
+   
+
+## Templates 
+These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
+

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -144,6 +144,7 @@ spec:
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
+          argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
@@ -203,12 +204,12 @@ spec:
       name: Create ArgoCD Resources
       action: argocd:create-resources
       input:
-        appName: ${{ parameters.name }}
+        appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: ${{ parameters.namespace}}
+        namespace: openshift-gitops 
         repoUrl: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops.git
-        path: './components/${{ parameters.name }}/overlays/development'
+        path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:

--- a/templates/devfile-sample-python-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-python-dance/content/docs/pipelines.md
@@ -1,12 +1,19 @@
-# docker-build-shared with shared pipeline references 
+# docker-build-rhtap
+
+## Shared Git resolver model for shared pipeline and tasks. 
  
-This component pipeline is used to create dockerfile builds. 
-The task references come from [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repository , `pipelines` `tasks` and are referenced by URL 
+This pipeline is used to create dockerfile based sscs builds. 
+Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in [tssc-sample-pipeline](https://github.com/redhat-appstudio/tssc-sample-pipelines) repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
  `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
+   
+
+## Templates 
+These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
+

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -144,6 +144,7 @@ spec:
           repoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops
           srcRepoURL: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
+          argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
@@ -203,12 +204,12 @@ spec:
       name: Create ArgoCD Resources
       action: argocd:create-resources
       input:
-        appName: ${{ parameters.name }}
+        appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: ${{ parameters.namespace}}
+        namespace: openshift-gitops 
         repoUrl: https://${{ (parameters.repoUrl | parseRepoUrl).host }}/${{ (parameters.repoUrl | parseRepoUrl).owner }}/${{ (parameters.repoUrl | parseRepoUrl).repo }}-gitops.git
-        path: './components/${{ parameters.name }}/overlays/development'
+        path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:


### PR DESCRIPTION
This pull requests adds a gitops app of apps to create three environments for an RHTAP template.
`development`, `stage`, `prod`

- the default argocd app is now created in openshift-pipelines, it creates applications for each of the namespaces (create = true)
- the argocd app selector for the plugin uses a new label `rhtap/gitops` to collect all of the plugins