### PR TITLE
add secret reference

### DIFF
--- a/properties
+++ b/properties
@@ -3,8 +3,15 @@ export GITHUB__DEFAULT__HOST=github.com
 export GITLAB__DEFAULT__HOST=gitlab.com
 export QUAY__DEFAULT__HOST=quay.io
 
+export DEFAULT__DEPLOYMENT__NAMESPACE__PREFIX=rhtap-app
+
 export ARGOCD__DEFAULT__NAMESPACE=rhtap
 export ARGOCD__DEFAULT__INSTANCE=default
 export ARGOCD__DEFAULT__PROJECT=default
 
-export DEFAULT__DEPLOYMENT__NAMESPACE__PREFIX=rhtap-app
+
+# For secret reference in Repositroy CRs
+export GIT__SECRET__DEFAULT__NAME=gitops-auth-secret
+export GIT__SECRET__DEFAULT__KEY=password
+export WEBHOOK__SECRET__DEFAULT__NAME=rhtap-pipelines-secret
+export WEBHOOK__SECRET__DEFAULT__KEY=webhook-github-secret

--- a/scripts/import-gitops-template
+++ b/scripts/import-gitops-template
@@ -46,5 +46,3 @@ iterate $DEST/components
 iterate $DEST/app-of-apps
 
 
-cp -r  $DEST/.tekton/*-repository.yaml $DEST/components/http/overlays/development    # temporary workaround for gitops
-

--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -192,6 +192,11 @@ spec:
           port: sed.edit.IMAGEPORT
           argoNS: ${ARGOCD__DEFAULT__NAMESPACE}
           argoProject: ${ARGOCD__DEFAULT__PROJECT}
+          secretRef: ${{ parameters.hostType === 'GitLab' }}
+          gitSecret: ${GIT__SECRET__DEFAULT__NAME}
+          gitSecretKey: ${GIT__SECRET__DEFAULT__KEY}
+          webhookSecret: ${WEBHOOK__SECRET__DEFAULT__NAME}
+          webhookSecretKey: ${WEBHOOK__SECRET__DEFAULT__KEY}
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/skeleton/gitops-template/.tekton/gitops-on-pull-request.yaml
+++ b/skeleton/gitops-template/.tekton/gitops-on-pull-request.yaml
@@ -21,6 +21,8 @@ spec:
       value: '{{repo_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: target-branch
+      value: '{{target_branch}}'
   pipelineRef:
     name: gitops-pull-request
   workspaces:

--- a/skeleton/gitops-template/components/http/overlays/development/gitops-repository.yaml
+++ b/skeleton/gitops-template/components/http/overlays/development/gitops-repository.yaml
@@ -4,3 +4,12 @@ metadata:
   name: ${{ values.appName }}-repository
 spec:
   url: ${{ values.repoURL }}
+  {%- if values.secretRef %}
+  git_provider:
+    secret:
+        name: ${{ values.gitSecret }}
+        key: ${{ values.gitSecretKey }}
+    webhook_secret:
+        name: ${{ values.webhookSecret }}
+        key:  ${{ values.webhookSecretKey }}
+  {%- endif %}

--- a/skeleton/gitops-template/components/http/overlays/development/source-repository.yaml
+++ b/skeleton/gitops-template/components/http/overlays/development/source-repository.yaml
@@ -4,3 +4,12 @@ metadata:
   name: ${{ values.name }}-repository
 spec:
   url: ${{ values.srcRepoURL }}
+  {%- if values.secretRef %}
+  git_provider:
+    secret:
+        name: ${{ values.gitSecret }}
+        key: ${{ values.gitSecretKey }}
+    webhook_secret:
+        name: ${{ values.webhookSecret }}
+        key:  ${{ values.webhookSecretKey }}
+  {%- endif %}

--- a/templates/devfile-sample-code-with-quarkus-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-code-with-quarkus-dance/content/docs/pipelines.md
@@ -2,18 +2,21 @@
 
 ## Shared Git resolver model for shared pipeline and tasks. 
  
-This pipeline is used to create dockerfile based sscs builds. 
-Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
+This pipeline is used to create dockerfile based sscs builds. The pipeline run by this runner will clone the source, build an image with SBOM, and attestations and push these to the users image registry.  
+
+Tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in this repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs in existin pipelines are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
- `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
-   
+To override the git-clone task, you may simply copy the git reference into your .tekton directory and then reference it from the remote task annotation. 
+
+`pipelinesascode.tekton.dev/task-0: "./tekton/git-clone.yaml"` 
 
 ## Templates 
 These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
 
+The intent of the template is to be able to fork this repository and update its use in the Developer Hub templates directory. 

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -192,6 +192,11 @@ spec:
           port: 8081
           argoNS: rhtap
           argoProject: default
+          secretRef: ${{ parameters.hostType === 'GitLab' }}
+          gitSecret: gitops-auth-secret
+          gitSecretKey: password
+          webhookSecret: rhtap-pipelines-secret
+          webhookSecretKey: webhook-github-secret
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/devfile-sample-dotnet60-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-dotnet60-dance/content/docs/pipelines.md
@@ -2,18 +2,21 @@
 
 ## Shared Git resolver model for shared pipeline and tasks. 
  
-This pipeline is used to create dockerfile based sscs builds. 
-Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
+This pipeline is used to create dockerfile based sscs builds. The pipeline run by this runner will clone the source, build an image with SBOM, and attestations and push these to the users image registry.  
+
+Tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in this repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs in existin pipelines are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
- `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
-   
+To override the git-clone task, you may simply copy the git reference into your .tekton directory and then reference it from the remote task annotation. 
+
+`pipelinesascode.tekton.dev/task-0: "./tekton/git-clone.yaml"` 
 
 ## Templates 
 These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
 
+The intent of the template is to be able to fork this repository and update its use in the Developer Hub templates directory. 

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -192,6 +192,11 @@ spec:
           port: 8081
           argoNS: rhtap
           argoProject: default
+          secretRef: ${{ parameters.hostType === 'GitLab' }}
+          gitSecret: gitops-auth-secret
+          gitSecretKey: password
+          webhookSecret: rhtap-pipelines-secret
+          webhookSecretKey: webhook-github-secret
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/devfile-sample-go-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-go-dance/content/docs/pipelines.md
@@ -2,18 +2,21 @@
 
 ## Shared Git resolver model for shared pipeline and tasks. 
  
-This pipeline is used to create dockerfile based sscs builds. 
-Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
+This pipeline is used to create dockerfile based sscs builds. The pipeline run by this runner will clone the source, build an image with SBOM, and attestations and push these to the users image registry.  
+
+Tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in this repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs in existin pipelines are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
- `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
-   
+To override the git-clone task, you may simply copy the git reference into your .tekton directory and then reference it from the remote task annotation. 
+
+`pipelinesascode.tekton.dev/task-0: "./tekton/git-clone.yaml"` 
 
 ## Templates 
 These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
 
+The intent of the template is to be able to fork this repository and update its use in the Developer Hub templates directory. 

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -192,6 +192,11 @@ spec:
           port: 8081
           argoNS: rhtap
           argoProject: default
+          secretRef: ${{ parameters.hostType === 'GitLab' }}
+          gitSecret: gitops-auth-secret
+          gitSecretKey: password
+          webhookSecret: rhtap-pipelines-secret
+          webhookSecretKey: webhook-github-secret
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/devfile-sample-java-springboot-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-java-springboot-dance/content/docs/pipelines.md
@@ -2,18 +2,21 @@
 
 ## Shared Git resolver model for shared pipeline and tasks. 
  
-This pipeline is used to create dockerfile based sscs builds. 
-Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
+This pipeline is used to create dockerfile based sscs builds. The pipeline run by this runner will clone the source, build an image with SBOM, and attestations and push these to the users image registry.  
+
+Tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in this repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs in existin pipelines are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
- `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
-   
+To override the git-clone task, you may simply copy the git reference into your .tekton directory and then reference it from the remote task annotation. 
+
+`pipelinesascode.tekton.dev/task-0: "./tekton/git-clone.yaml"` 
 
 ## Templates 
 These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
 
+The intent of the template is to be able to fork this repository and update its use in the Developer Hub templates directory. 

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -192,6 +192,11 @@ spec:
           port: 8081
           argoNS: rhtap
           argoProject: default
+          secretRef: ${{ parameters.hostType === 'GitLab' }}
+          gitSecret: gitops-auth-secret
+          gitSecretKey: password
+          webhookSecret: rhtap-pipelines-secret
+          webhookSecretKey: webhook-github-secret
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/devfile-sample-nodejs-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-nodejs-dance/content/docs/pipelines.md
@@ -2,18 +2,21 @@
 
 ## Shared Git resolver model for shared pipeline and tasks. 
  
-This pipeline is used to create dockerfile based sscs builds. 
-Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
+This pipeline is used to create dockerfile based sscs builds. The pipeline run by this runner will clone the source, build an image with SBOM, and attestations and push these to the users image registry.  
+
+Tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in this repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs in existin pipelines are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
- `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
-   
+To override the git-clone task, you may simply copy the git reference into your .tekton directory and then reference it from the remote task annotation. 
+
+`pipelinesascode.tekton.dev/task-0: "./tekton/git-clone.yaml"` 
 
 ## Templates 
 These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
 
+The intent of the template is to be able to fork this repository and update its use in the Developer Hub templates directory. 

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -192,6 +192,11 @@ spec:
           port: 3001
           argoNS: rhtap
           argoProject: default
+          secretRef: ${{ parameters.hostType === 'GitLab' }}
+          gitSecret: gitops-auth-secret
+          gitSecretKey: password
+          webhookSecret: rhtap-pipelines-secret
+          webhookSecretKey: webhook-github-secret
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/devfile-sample-python-dance/content/docs/pipelines.md
+++ b/templates/devfile-sample-python-dance/content/docs/pipelines.md
@@ -2,18 +2,21 @@
 
 ## Shared Git resolver model for shared pipeline and tasks. 
  
-This pipeline is used to create dockerfile based sscs builds. 
-Tasks tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
+This pipeline is used to create dockerfile based sscs builds. The pipeline run by this runner will clone the source, build an image with SBOM, and attestations and push these to the users image registry.  
+
+Tasks references come from this repository ` ../pipelines` `../tasks` and are referenced by URL using the git resolver in tekton. 
  
-When the pipleines in this repo are updated, all future runs are shared.
+When the pipleines in this repo are updated, all future runs in existin pipelines are shared.
 
 A developer can override these tasks with a local copy and updated annotations. 
 
 Example 
 
- `pipelinesascode.tekton.dev/task: "./tasks/show-sbom.yaml `
-   
+To override the git-clone task, you may simply copy the git reference into your .tekton directory and then reference it from the remote task annotation. 
+
+`pipelinesascode.tekton.dev/task-0: "./tekton/git-clone.yaml"` 
 
 ## Templates 
 These pipelines are in template format. The references to this repository in the PaC template is `{{values.rawUrl}}` which is updated to point to this repo or the fork of this repo.
 
+The intent of the template is to be able to fork this repository and update its use in the Developer Hub templates directory. 

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -192,6 +192,11 @@ spec:
           port: 8081
           argoNS: rhtap
           argoProject: default
+          secretRef: ${{ parameters.hostType === 'GitLab' }}
+          gitSecret: gitops-auth-secret
+          gitSecretKey: password
+          webhookSecret: rhtap-pipelines-secret
+          webhookSecretKey: webhook-github-secret
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory


### PR DESCRIPTION
fixes issue: https://issues.redhat.com/browse/DEVHAS-632

Add git secret and webhook secret reference in repository CRs if hostType is `GitLab`
(currently only GitLab requires the reference, since github uses app integration)


This change requires the installer issue to be done
https://issues.redhat.com/browse/RHTAPBUGS-1177


to workaround and test this PR: manually create webhook secret under rhtap-app-development ns
```
kubectl -n rhtap-app-development  create secret generic rhtap-pipelines-secret --from-literal webhook-github-secret=SECRET_AS_SET_IN_WEBHOOK_CONFIGURATION
```