### PR TITLE
gitops-pull-request: pass the target branch param

### DIFF
--- a/skeleton/gitops-template/.tekton/gitops-on-pull-request.yaml
+++ b/skeleton/gitops-template/.tekton/gitops-on-pull-request.yaml
@@ -21,6 +21,8 @@ spec:
       value: '{{repo_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: target-branch
+      value: '{{target_branch}}'
   pipelineRef:
     name: gitops-pull-request
   workspaces:


### PR DESCRIPTION
The gitops-pull-request pipeline accepts a target-branch param, which
defaults to 'main'. Use the corresponding PaC variable to make sure the
target branch will be correct.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>