### PR TITLE
WIP: Initialize namespace Job

### DIFF
--- a/skeleton/gitops-template/components/http/base/initialize-namespace.yaml
+++ b/skeleton/gitops-template/components/http/base/initialize-namespace.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: initialize-namespace
+spec: 
+  ttlSecondsAfterFinished: 3
+  template:         
+    metadata:
+      name: initialize-namespace 
+    spec:  
+      serviceAccountName: pipeline
+      containers:
+      - name: initialize-namespace
+        image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+        command:
+        - /bin/bash
+        - -c
+        - |
+          NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) 
+          echo "Initialize RHTAP Namespace: $NS"  
+          cat <<CONFIGURE_PIPELINE | oc create -f - 
+          apiVersion: tekton.dev/v1
+          kind: PipelineRun
+          metadata:
+            generateName: rhtap-dev-namespace-setup-
+            namespace: $NS 
+          spec:
+            pipelineSpec:
+              tasks:
+                - name: configure-namespace
+                  taskRef:
+                    kind: Task
+                    params:
+                      - name: kind
+                        value: task
+                      - name: name
+                        value: rhtap-dev-namespace-setup
+                      - name: namespace
+                        value: rhtap
+                    resolver: cluster 
+          CONFIGURE_PIPELINE
+          
+      restartPolicy: Never

--- a/skeleton/gitops-template/components/http/base/initialize-namespace.yaml
+++ b/skeleton/gitops-template/components/http/base/initialize-namespace.yaml
@@ -2,8 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: initialize-namespace
-spec: 
-  ttlSecondsAfterFinished: 3
+spec:  
   template:         
     metadata:
       name: initialize-namespace 

--- a/skeleton/gitops-template/components/http/base/kustomization.yaml
+++ b/skeleton/gitops-template/components/http/base/kustomization.yaml
@@ -7,6 +7,7 @@ commonLabels:
   backstage.io/kubernetes-namespace: ${{  values.namespace  }} 
   app.kubernetes.io/part-of: ${{  values.name  }}
 resources: 
+- initialize-namespace.yaml
 - deployment.yaml
 - route.yaml
-- service.yaml
+- service.yaml 


### PR DESCRIPTION
This pull request adds a job per namespace to initialize each namespace by running the setup pipeline launched from a job. 

When using this job, any new namespaces created by the app-of-apps will be initialized correctly for use. 

This is a WIP - the namespace to find the task is assumed to be `rhtap`
Will need to be put into the gitops repo as well as parameterized to hold the rhtap install namespace. 

