### PR TITLE
Add #!/bin/bash shebang to scripts

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
 
 # pull in latest pipeline run definition

--- a/scripts/import-gitops-template
+++ b/scripts/import-gitops-template
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
 ROOTDIR=$(realpath $SCRIPTDIR/..)
 

--- a/scripts/import-repo
+++ b/scripts/import-repo
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
 
 $SCRIPTDIR/import-samples https://github.com/redhat-appstudio/devfile-sample-nodejs-dance

--- a/scripts/import-samples
+++ b/scripts/import-samples
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
 ROOT_DIR=$(realpath $SCRIPTDIR/..)
 

--- a/scripts/update-tekton-definition
+++ b/scripts/update-tekton-definition
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
 ROOTDIR=$(realpath $SCRIPTDIR/..)
 
@@ -53,4 +55,3 @@ for prun in $SRC_TEKTON/*.yaml $GITOPS_TEKTON/*.yaml; do
         echo "Labels for $prun" 
         add-backstage-labels $prun
 done 
- 


### PR DESCRIPTION
When I run ./generate.sh, my machine executes the script via /bin/sh. And yes, /bin/sh is a symlink to /bin/bash. However! As seen in the bash manpage, or in https://tiswww.case.edu/php/chet/bash/POSIX:

    When invoked as 'sh', Bash enters POSIX mode after reading the
    startup files.

Item 15. in POSIX mode:

    Function names must be valid shell 'name's.  That is, they may not
    contain characters other than letters, digits, and underscores, and
    may not start with a digit.  Declaring a function with an invalid
    name causes a fatal syntax error in non-interactive shells.

This causes scripts/update-tekton-definition to fail on

    function add-backstage-labels () { ... }

Add explicit #!/bin/bash shebang to all scripts to avoid POSIX/non-POSIX issues.