### PR TITLE
Increase the visibility of cosign signing secret vars

### DIFF
--- a/skeleton/ci/gitops-template/jenkins/Jenkinsfile
+++ b/skeleton/ci/gitops-template/jenkins/Jenkinsfile
@@ -4,6 +4,9 @@ library identifier: 'RHTAP_Jenkins@main', retriever: modernSCM(
 
 pipeline {
     agent any
+    environment {
+        COSIGN_PUBLIC_KEY = credentials('COSIGN_PUBLIC_KEY')
+    }
     stages {
         stage('Compute Image Changes') {
             steps {
@@ -14,9 +17,6 @@ pipeline {
             }
         }
         stage('Verify EC') {
-            environment {
-                COSIGN_PUBLIC_KEY = credentials('COSIGN_PUBLIC_KEY')
-            }
             steps {
                 script {
                     rhtap.info('verify_enterprise_contract')

--- a/skeleton/ci/gitops-template/jenkins/Jenkinsfile
+++ b/skeleton/ci/gitops-template/jenkins/Jenkinsfile
@@ -5,6 +5,9 @@ library identifier: 'RHTAP_Jenkins@main', retriever: modernSCM(
 pipeline {
     agent any
     environment {
+        // Only COSIGN_PUBLIC_KEY is needed but init.sh will fail otherwise
+        COSIGN_SECRET_PASSWORD = credentials('COSIGN_SECRET_PASSWORD')
+        COSIGN_SECRET_KEY = credentials('COSIGN_SECRET_KEY')
         COSIGN_PUBLIC_KEY = credentials('COSIGN_PUBLIC_KEY')
     }
     stages {

--- a/skeleton/ci/source-repo/jenkins/Jenkinsfile
+++ b/skeleton/ci/source-repo/jenkins/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline {
         ROX_CENTRAL_ENDPOINT = credentials('ROX_CENTRAL_ENDPOINT')
         GITOPS_AUTH_PASSWORD = credentials('GITOPS_AUTH_PASSWORD')
         QUAY_IO_CREDS = credentials('QUAY_IO_CREDS')
+        COSIGN_SECRET_PASSWORD = credentials('COSIGN_SECRET_PASSWORD')
+        COSIGN_SECRET_KEY = credentials('COSIGN_SECRET_KEY')
+        COSIGN_PUBLIC_KEY = credentials('COSIGN_PUBLIC_KEY')
     }
     stages {
         stage('init') {
@@ -29,11 +32,6 @@ pipeline {
             }
         }
         stage('sign-attest') {
-            environment {
-                COSIGN_SECRET_PASSWORD = credentials('COSIGN_SECRET_PASSWORD')
-                COSIGN_SECRET_KEY = credentials('COSIGN_SECRET_KEY')
-                COSIGN_PUBLIC_KEY = credentials('COSIGN_PUBLIC_KEY')
-            }
             steps {
                 script {
                     rhtap.info('cosign_sign_attest')


### PR DESCRIPTION
Even though the signing secret vars are not needed, and ideally we should not make the available everwhere, there is a init.sh script that fails when vars are not found. As a quick-fix, just make sure they're defined everywhere.

Ref: https://issues.redhat.com/browse/RHTAPBUGS-1279