### PR TITLE
Adds gitops-auth workspace to docker-push

### DIFF
--- a/skeleton/ci/source-repo/tekton/.tekton/docker-push.yaml
+++ b/skeleton/ci/source-repo/tekton/.tekton/docker-push.yaml
@@ -43,6 +43,9 @@ spec:
   pipelineRef:
     name: docker-build-rhtap
   workspaces:
+    - name: gitops-auth
+      secret:
+        secretName: $(params.gitops-auth-secret-name)
     - name: git-auth
       secret:
         secretName: "{{ git_auth_secret }}"


### PR DESCRIPTION
All changes in this PR were generated using the 'generate.sh' script.

This PR adds 'gitops-auth' workspace to 'docker-push.yaml'.