### PR TITLE
fix: use a 'raw' URL compatible with GH enterprise

### DIFF
--- a/scripts/import-samples
+++ b/scripts/import-samples
@@ -12,7 +12,7 @@ if [ -d $SAMPLE_DIR ]; then
 else 
     (cd $SCRIPTDIR/samples;  git clone $REPO 2>&1 > /dev/null)
 fi
- 
+
 APP_NAME=$(yq ".metadata.name" $SAMPLE_DIR/devfile.yaml)
 APP_DISPLAY_NAME=$(yq ".metadata.displayName" $SAMPLE_DIR/devfile.yaml)
 APP_DESC=$(yq ".metadata.description" $SAMPLE_DIR/devfile.yaml)
@@ -37,7 +37,7 @@ cp -r $ROOT_DIR/skeleton/backstage/mkdocs.yml  $DEST/content/mkdocs.yml
 
 # get readme to source component doc
 cp -r $DEST/content/README.md  $DEST/content/docs/source-component.md
- 
+
 sed -i "s!sed.edit.NAME!$APP_NAME!g" $DEST/template.yaml
 sed -i "s!sed.edit.TITLE!$APP_DISPLAY_NAME!g" $DEST/template.yaml
 sed -i "s!sed.edit.DESCRIPTION!$APP_DESC!g" $DEST/template.yaml

--- a/scripts/update-tekton-definition
+++ b/scripts/update-tekton-definition
@@ -7,8 +7,8 @@ source $ROOTDIR/properties
 
 REPO="${1:-$PIPELINE__REPO__URL}"
 BRANCH="${2:-$PIPELINE__REPO__BRANCH}"
-RAW_BASE=$(echo $REPO/$BRANCH |  sed "s/github.com/raw.githubusercontent.com/")  
-REPONAME=$(basename $REPO)
+RAW_BASE="$REPO/blob/$(echo $BRANCH | sed "s|/|%2F|g")"
+REPONAME="$(basename $REPO)"
 
 TEMPDIR=$ROOTDIR/temp
 rm -rf $TEMPDIR # clean up
@@ -50,7 +50,7 @@ mkdir -p $GITOPS_TEKTON/../docs
 cp -r $GITOPS_TEKTON/README.md  $GITOPS_TEKTON/../docs/pipelines.md
 
 rm -rf $TEMPDIR
- 
+
 for prun in $SRC_TEKTON/*.yaml $GITOPS_TEKTON/*.yaml; do 
         echo "Labels for $prun" 
         add-backstage-labels $prun


### PR DESCRIPTION
The use of 'raw.githubusercontent.com' is incompatible with on-prem deployments of GitHub.
   
On the other hand, 'blob' is valid on both community and on-prem deployments.
Cf https://pipelinesascode.com/docs/guide/resolver/#remote-http-url-from-a-private-repository