### PR TITLE
switch to konflux built images

### DIFF
--- a/skeleton/ci/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/skeleton/ci/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -40,7 +40,7 @@ jobs:
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner
+      image: quay.io/redhat-appstudio/rhtap-task-runner:latest
     environment: production
 
     steps:

--- a/skeleton/ci/gitops-template/gitlabci/.gitlab-ci.yml
+++ b/skeleton/ci/gitops-template/gitlabci/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # Generated from templates/gitops-template/.gitlab-ci.yml.njk. Do not edit directly.
 
-image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner
+image: quay.io/redhat-appstudio/rhtap-task-runner:latest
 
 variables:
   CI_TYPE: gitlab

--- a/skeleton/ci/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/skeleton/ci/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -45,7 +45,7 @@ jobs:
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner
+      image: quay.io/redhat-appstudio/rhtap-task-runner:latest
       options: --privileged
     environment: production
 

--- a/skeleton/ci/source-repo/gitlabci/.gitlab-ci.yml
+++ b/skeleton/ci/source-repo/gitlabci/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # Generated from templates/source-repo/.gitlab-ci.yml.njk. Do not edit directly.
 
-image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner
+image: quay.io/redhat-appstudio/rhtap-task-runner:latest
 
 variables:
   CI_TYPE: gitlab


### PR DESCRIPTION

Switch gitlab pipelines and github workflows to use konflux images. 
These have the same content as the prior images, just built by konflux 