### PR TITLE
RHTAP-4061 Fix CD & Docs tab in -gitops component

### DIFF
--- a/skeleton/gitops-template/catalog-info.yaml
+++ b/skeleton/gitops-template/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
       icon: dashboard
       type: admin-dashboard
   annotations:    
-    argocd/app-name: ${{ values.name }}
+    argocd/app-selector: rhtap/gitops=${{  values.name  }}
     backstage.io/kubernetes-id: ${{ values.name }} 
     backstage.io/techdocs-ref: dir:.   
   {%- if values.ciType == 'tekton' %} 

--- a/skeleton/gitops-template/docs/index.md
+++ b/skeleton/gitops-template/docs/index.md
@@ -1,0 +1,8 @@
+# GitOps Http Application Sample
+
+## HTTP Application 
+This Gitops sample provides a standard HTTP component consisting of a deployment, service and route. 
+
+The following day 2 edit/update operations supported:
+    set/get image - updates the image for this component 
+    set/get replicas


### PR DESCRIPTION
Changes to correct argocd/app-selecor in -gitops resource. Now the CD tab shows the same info as "main" component.
This also adds `index.md` to the -gitops repo, so it is rendered in Docs tab in Backstage.