### PR TITLE
feat: split gitops resources in their own namespace

### DIFF
--- a/properties
+++ b/properties
@@ -18,7 +18,7 @@ export PIPELINE__REPO__BRANCH=main
 export DEFAULT__DEPLOYMENT__NAMESPACE__PREFIX=rhtap-app
 
 export RHTAP__DEFAULT__NAMESPACE=rhtap
-export ARGOCD__DEFAULT__NAMESPACE=rhtap
+export ARGOCD__DEFAULT__NAMESPACE=rhtap-gitops
 export ARGOCD__DEFAULT__INSTANCE=default
 export ARGOCD__DEFAULT__PROJECT=default
 

--- a/skeleton/gitops-template/application.yaml
+++ b/skeleton/gitops-template/application.yaml
@@ -11,7 +11,7 @@ spec:
     repoURL: ${{ values.repoURL }}.git
     targetRevision: ${{ values.defaultBranch }}
   destination:
-    namespace: ${{ values.namespace }}
+    namespace: ${{ values.argoNS }}
     server: https://kubernetes.default.svc
   syncPolicy:
     managedNamespaceMetadata:

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -309,7 +309,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default 
           ciType: ${{ parameters.ciType }} 
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
@@ -347,7 +347,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default
           hostType: ${{ parameters.hostType }} 
           username: ${{ parameters.bbOwner }} 
@@ -429,7 +429,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: rhtap-gitops
         repoUrl: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -309,7 +309,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default 
           ciType: ${{ parameters.ciType }} 
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
@@ -347,7 +347,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default
           hostType: ${{ parameters.hostType }} 
           username: ${{ parameters.bbOwner }} 
@@ -429,7 +429,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: rhtap-gitops
         repoUrl: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -309,7 +309,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default 
           ciType: ${{ parameters.ciType }} 
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
@@ -347,7 +347,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default
           hostType: ${{ parameters.hostType }} 
           username: ${{ parameters.bbOwner }} 
@@ -429,7 +429,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: rhtap-gitops
         repoUrl: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -309,7 +309,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default 
           ciType: ${{ parameters.ciType }} 
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
@@ -347,7 +347,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default
           hostType: ${{ parameters.hostType }} 
           username: ${{ parameters.bbOwner }} 
@@ -429,7 +429,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: rhtap-gitops
         repoUrl: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -309,7 +309,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 3001
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default 
           ciType: ${{ parameters.ciType }} 
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
@@ -347,7 +347,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 3001
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default
           hostType: ${{ parameters.hostType }} 
           username: ${{ parameters.bbOwner }} 
@@ -429,7 +429,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: rhtap-gitops
         repoUrl: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -309,7 +309,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default 
           ciType: ${{ parameters.ciType }} 
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
@@ -347,7 +347,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default
           hostType: ${{ parameters.hostType }} 
           username: ${{ parameters.bbOwner }} 
@@ -429,7 +429,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: rhtap-gitops
         repoUrl: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.

--- a/templates/generic-import-from-repo/template.yaml
+++ b/templates/generic-import-from-repo/template.yaml
@@ -344,7 +344,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: ${{ parameters.appPort }} 
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default 
           ciType: ${{ parameters.ciType }} 
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
@@ -382,7 +382,7 @@ spec:
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: ${{ parameters.appPort }} 
-          argoNS: rhtap
+          argoNS: rhtap-gitops
           argoProject: default
           hostType: ${{ parameters.hostType }} 
           username: ${{ parameters.bbOwner }} 
@@ -464,7 +464,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: rhtap-gitops
         repoUrl: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
   # Outputs are displayed to the user after a successful execution of the template.


### PR DESCRIPTION
Starting with RHTAP installer 1.5, GitOps has its own namespace to better segregate its resources.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED