### PR TITLE
feat: CI workloads have their own namespace

### DIFF
--- a/skeleton/backstage/docs/index.md
+++ b/skeleton/backstage/docs/index.md
@@ -16,7 +16,8 @@ The gitops repository, which contains the kubernetes manifests for the applicati
 The default application will be found in the following namespaces. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
 
 |  Namespace   |  Description   |  
-| -------- | -------- |   
-| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. | 
-| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |  
-| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory | 
+| -------- | -------- |
+| **${{ values.namespace }}-ci** | The namespace used for CI workloads |
+| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. |
+| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/stage directory |
+| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |

--- a/skeleton/gitops-template/app-of-apps/ci-tekton.yaml
+++ b/skeleton/gitops-template/app-of-apps/ci-tekton.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.name }}-ci
+  namespace: ${{ values.argoNS }}
+  finalizers: ["resources-finalizer.argocd.argoproj.io"]
+spec:
+  project: ${{ values.argoProject }}
+  source:
+    path: ${{ values.argoComponentOverlays }}/ci
+    repoURL: ${{ values.repoURL }}.git
+    targetRevision: ${{ values.defaultBranch }}
+  destination:
+    namespace: ${{ values.namespace }}-ci
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/managed-by: ${{ values.argoNS }}
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true

--- a/skeleton/gitops-template/app-of-apps/kustomization.yaml
+++ b/skeleton/gitops-template/app-of-apps/kustomization.yaml
@@ -6,7 +6,10 @@ commonLabels:
   backstage.io/kubernetes-id: ${{ values.name }}
   backstage.io/kubernetes-namespace: ${{ values.namespace }} 
   app.kubernetes.io/part-of: ${{ values.name }}
-resources: 
-- application-dev.yaml 
-- application-stage.yaml 
-- application-prod.yaml  
+resources:
+{%- if values.isTekton %}
+  - ci-tekton.yaml
+{%- endif %}
+  - application-dev.yaml
+  - application-stage.yaml
+  - application-prod.yaml

--- a/skeleton/gitops-template/components/http/overlays/ci/gitops-repository.yaml
+++ b/skeleton/gitops-template/components/http/overlays/ci/gitops-repository.yaml
@@ -1,20 +1,20 @@
 apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
 kind: Repository
 metadata:
-  name: ${{ values.name }}-repository
+  name: ${{ values.appName }}-repository
 spec:
-  url: ${{ values.srcRepoURL }}
+  url: ${{ values.repoURL }}
   {%- if values.secretRef %}
   git_provider:
     {%- if values.hostType == 'Bitbucket' %}
     user: ${{ values.username }}
     {%- endif %}
     secret:
-        name: ${{ values.gitSecret }}
-        key: ${{ values.gitSecretKey }}
+      name: ${{ values.gitSecret }}
+      key: ${{ values.gitSecretKey }}
     {%- if values.hostType == 'Gitlab' %}
     webhook_secret:
-        name: ${{ values.webhookSecret }}
-        key:  ${{ values.webhookSecretKey }}
+      name: ${{ values.webhookSecret }}
+      key:  ${{ values.webhookSecretKey }}
     {%- endif %}
   {%- endif %}

--- a/skeleton/gitops-template/components/http/overlays/ci/kustomization.yaml
+++ b/skeleton/gitops-template/components/http/overlays/ci/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patchesStrategicMerge:
-  - deployment-patch.yaml
 resources:
-  - ../../base
+  - gitops-repository.yaml
+  - source-repository.yaml

--- a/skeleton/gitops-template/components/http/overlays/ci/source-repository.yaml
+++ b/skeleton/gitops-template/components/http/overlays/ci/source-repository.yaml
@@ -1,20 +1,20 @@
 apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
 kind: Repository
 metadata:
-  name: ${{ values.appName }}-repository
+  name: ${{ values.name }}-repository
 spec:
-  url: ${{ values.repoURL }}
+  url: ${{ values.srcRepoURL }}
   {%- if values.secretRef %}
   git_provider:
     {%- if values.hostType == 'Bitbucket' %}
     user: ${{ values.username }}
     {%- endif %}
     secret:
-        name: ${{ values.gitSecret }}
-        key: ${{ values.gitSecretKey }}
+      name: ${{ values.gitSecret }}
+      key: ${{ values.gitSecretKey }}
     {%- if values.hostType == 'Gitlab' %}
     webhook_secret:
-        name: ${{ values.webhookSecret }}
-        key:  ${{ values.webhookSecretKey }}
+      name: ${{ values.webhookSecret }}
+      key:  ${{ values.webhookSecretKey }}
     {%- endif %}
   {%- endif %}

--- a/templates/devfile-sample-code-with-quarkus-dance/content/docs/index.md
+++ b/templates/devfile-sample-code-with-quarkus-dance/content/docs/index.md
@@ -16,7 +16,8 @@ The gitops repository, which contains the kubernetes manifests for the applicati
 The default application will be found in the following namespaces. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
 
 |  Namespace   |  Description   |  
-| -------- | -------- |   
-| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. | 
-| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |  
-| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory | 
+| -------- | -------- |
+| **${{ values.namespace }}-ci** | The namespace used for CI workloads |
+| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. |
+| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/stage directory |
+| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |

--- a/templates/devfile-sample-dotnet60-dance/content/docs/index.md
+++ b/templates/devfile-sample-dotnet60-dance/content/docs/index.md
@@ -16,7 +16,8 @@ The gitops repository, which contains the kubernetes manifests for the applicati
 The default application will be found in the following namespaces. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
 
 |  Namespace   |  Description   |  
-| -------- | -------- |   
-| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. | 
-| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |  
-| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory | 
+| -------- | -------- |
+| **${{ values.namespace }}-ci** | The namespace used for CI workloads |
+| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. |
+| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/stage directory |
+| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |

--- a/templates/devfile-sample-go-dance/content/docs/index.md
+++ b/templates/devfile-sample-go-dance/content/docs/index.md
@@ -16,7 +16,8 @@ The gitops repository, which contains the kubernetes manifests for the applicati
 The default application will be found in the following namespaces. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
 
 |  Namespace   |  Description   |  
-| -------- | -------- |   
-| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. | 
-| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |  
-| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory | 
+| -------- | -------- |
+| **${{ values.namespace }}-ci** | The namespace used for CI workloads |
+| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. |
+| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/stage directory |
+| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |

--- a/templates/devfile-sample-java-springboot-dance/content/docs/index.md
+++ b/templates/devfile-sample-java-springboot-dance/content/docs/index.md
@@ -16,7 +16,8 @@ The gitops repository, which contains the kubernetes manifests for the applicati
 The default application will be found in the following namespaces. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
 
 |  Namespace   |  Description   |  
-| -------- | -------- |   
-| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. | 
-| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |  
-| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory | 
+| -------- | -------- |
+| **${{ values.namespace }}-ci** | The namespace used for CI workloads |
+| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. |
+| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/stage directory |
+| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |

--- a/templates/devfile-sample-nodejs-dance/content/docs/index.md
+++ b/templates/devfile-sample-nodejs-dance/content/docs/index.md
@@ -16,7 +16,8 @@ The gitops repository, which contains the kubernetes manifests for the applicati
 The default application will be found in the following namespaces. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
 
 |  Namespace   |  Description   |  
-| -------- | -------- |   
-| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. | 
-| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |  
-| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory | 
+| -------- | -------- |
+| **${{ values.namespace }}-ci** | The namespace used for CI workloads |
+| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. |
+| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/stage directory |
+| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |

--- a/templates/devfile-sample-python-dance/content/docs/index.md
+++ b/templates/devfile-sample-python-dance/content/docs/index.md
@@ -16,7 +16,8 @@ The gitops repository, which contains the kubernetes manifests for the applicati
 The default application will be found in the following namespaces. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
 
 |  Namespace   |  Description   |  
-| -------- | -------- |   
-| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. | 
-| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |  
-| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory | 
+| -------- | -------- |
+| **${{ values.namespace }}-ci** | The namespace used for CI workloads |
+| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. |
+| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/stage directory |
+| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |

--- a/templates/generic-import-from-repo/generate/docs/index.md
+++ b/templates/generic-import-from-repo/generate/docs/index.md
@@ -16,7 +16,8 @@ The gitops repository, which contains the kubernetes manifests for the applicati
 The default application will be found in the following namespaces. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
 
 |  Namespace   |  Description   |  
-| -------- | -------- |   
-| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. | 
-| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |  
-| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory | 
+| -------- | -------- |
+| **${{ values.namespace }}-ci** | The namespace used for CI workloads |
+| **${{ values.namespace }}-development** | The default application during development. Every build will be deployed to this namespace for testing. |
+| **${{ values.namespace }}-stage** | The staging namespace for this application. Promotion from development to stage is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/stage directory |
+| **${{ values.namespace }}-prod** | The production namespace for this application. Promotion from stage to production is manual via an update to the [gitops repository](${{ values.repoURL }} ) in the components/${{ values.name }}/overlays/prod directory |


### PR DESCRIPTION
There is no reason for the development application to run in a namespace with the extra secrets needed by the ci.

This split provides better segregation of information and makes the development namespace identical to the other deployment namespaces in term of configuration.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED