### PR TITLE
Display HTML BitBucket link in summary

### DIFF
--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -4,7 +4,7 @@ kind: Template
 metadata:
   name: sed.edit.NAME
   title:  sed.edit.TITLE
-  description: sed.edit.DESCRIPTION 
+  description: sed.edit.DESCRIPTION
   tags: sed.edit.APPTAGS
 spec:
   type: service
@@ -36,9 +36,9 @@ spec:
               kind: [Group, User]
     - title: Application Repository Information
       required:
-        - hostType 
+        - hostType
         - repoName
-        - branch 
+        - branch
       properties:
         hostType:
           title: Host Type
@@ -60,12 +60,12 @@ spec:
           oneOf:
             - required:
                 - ghHost
-                - ciType  
+                - ciType
                 - ghOwner
                 - hostType
               properties:
                 hostType:
-                  const: GitHub   
+                  const: GitHub
                 ghOwner:
                   title: Repository Owner
                   type: string
@@ -82,20 +82,20 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
-                    - githubactions 
+                    - jenkins
+                    - githubactions
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Github Actions (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Github Actions (SLSA 2)
             - required:
                 - glHost
-                - ciType  
+                - ciType
                 - glOwner
                 - hostType
               properties:
                 hostType:
-                    const: GitLab  
+                    const: GitLab
                 glOwner:
                   title: Repository Owner
                   type: string
@@ -116,18 +116,18 @@ spec:
                     - gitlabci
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Gitlab CI (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Gitlab CI (SLSA 2)
             - required:
                 - bbHost
-                - ciType  
+                - ciType
                 - bbOwner
-                - hostType   
+                - hostType
                 - workspace
                 - project
               properties:
                 hostType:
-                    const: Bitbucket  
+                    const: Bitbucket
                 bbOwner:
                   title: Repository Owner
                   type: string
@@ -140,11 +140,11 @@ spec:
                   ui:help: "Bitbucket Cloud Default"
                 workspace:
                   title: Workspace
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Workspace"
                 project:
                   title: Project
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Project"
                 ciType:
                   title: CI Provider
@@ -152,10 +152,10 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
+                    - jenkins
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2)   
+                    - Jenkins (SLSA 2)
     - title: Deployment information
       required:
         - imageRegistry
@@ -203,7 +203,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
-          
+
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
     - id: fetch-skeleton
       name: Fetch Skeleton
@@ -213,42 +213,42 @@ spec:
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: sed.edit.CATALOG_DESCRIPTION 
+          description: sed.edit.CATALOG_DESCRIPTION
           dockerfile: sed.edit.DOCKERFILE
-          buildContext: sed.edit.BUILDCONTEXT  
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          buildContext: sed.edit.BUILDCONTEXT
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           imageName: ${{ parameters.imageName }}
           tags: 'sed.edit.APPTAGS'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          hostType: ${{ parameters.hostType }} 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          defaultBranch: ${{ parameters.branch }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
     - id: fetch-ci-skeleton
       name: Fetch CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}  
+        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: sed.edit.CATALOG_DESCRIPTION 
+          description: sed.edit.CATALOG_DESCRIPTION
           dockerfile: sed.edit.DOCKERFILE
           buildContext: sed.edit.BUILDCONTEXT
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           tags: 'sed.edit.APPTAGS'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }}  
+          defaultBranch: ${{ parameters.branch }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to GitHub
@@ -304,31 +304,31 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: sed.edit.IMAGEPORT
           argoNS: ${ARGOCD__DEFAULT__NAMESPACE}
-          argoProject: ${ARGOCD__DEFAULT__PROJECT} 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          argoProject: ${ARGOCD__DEFAULT__PROJECT}
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: ${GIT__SECRET__DEFAULT__KEY}
           webhookSecret: ${WEBHOOK__SECRET__DEFAULT__NAME}
           webhookSecretKey: ${WEBHOOK__SECRET__DEFAULT__KEY}
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     # Fetch CI which will be in a folder ci/gitops/type
     - id: fetch-gitops-ci-skeleton
       name: Fetch Gitops CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}} 
+        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
         targetPath: gitops
         values:
           name: ${{ parameters.name }}
@@ -342,23 +342,23 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: sed.edit.IMAGEPORT
           argoNS: ${ARGOCD__DEFAULT__NAMESPACE}
           argoProject: ${ARGOCD__DEFAULT__PROJECT}
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }}  
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }}  
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: ${GIT__SECRET__DEFAULT__KEY}
           webhookSecret: ${WEBHOOK__SECRET__DEFAULT__NAME}
           webhookSecretKey: ${WEBHOOK__SECRET__DEFAULT__KEY}
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory
@@ -376,7 +376,7 @@ spec:
         allowedHosts: ['${{ parameters.ghHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.ghHost }}?owner=${{ parameters.ghOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
@@ -389,7 +389,7 @@ spec:
         allowedHosts: ['${{ parameters.glHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.glHost }}?owner=${{ parameters.glOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     - id: publish-bitbucket-gitops
@@ -401,10 +401,10 @@ spec:
         allowedHosts: ['${{ parameters.bbHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.bbHost }}?owner=${{ parameters.bbOwner }}&repo=${{ parameters.repoName }}-gitops&project=${{ parameters.project }}&workspace=${{ parameters.workspace }}
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
-                
+
     - id: wait-for-github-repository
       name: Waiting for repository availability
       action: 'debug:wait'
@@ -420,7 +420,7 @@ spec:
       name: Register Gitops
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}  
+        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
         catalogInfoPath: '/catalog-info.yaml'
     - id: create-argocd-resources
       name: Create ArgoCD Resources

--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -436,9 +436,9 @@ spec:
   output:
     links:
       - title: Source Repository
-        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.remoteUrl) }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.repoContentsUrl) }}
       - title: GitOps Repository
-        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.remoteUrl) }}
+        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -436,9 +436,9 @@ spec:
   output:
     links:
       - title: Source Repository
-        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.remoteUrl) }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.repoContentsUrl) }}
       - title: GitOps Repository
-        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.remoteUrl) }}
+        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -4,7 +4,7 @@ kind: Template
 metadata:
   name: java-quarkus
   title:  Quarkus Java - Trusted Application Pipeline
-  description: Quarkus Java example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+  description: Quarkus Java example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
   tags: ["java", "quarkus", "sscs", "sbom", "acs"]
 spec:
   type: service
@@ -36,9 +36,9 @@ spec:
               kind: [Group, User]
     - title: Application Repository Information
       required:
-        - hostType 
+        - hostType
         - repoName
-        - branch 
+        - branch
       properties:
         hostType:
           title: Host Type
@@ -60,12 +60,12 @@ spec:
           oneOf:
             - required:
                 - ghHost
-                - ciType  
+                - ciType
                 - ghOwner
                 - hostType
               properties:
                 hostType:
-                  const: GitHub   
+                  const: GitHub
                 ghOwner:
                   title: Repository Owner
                   type: string
@@ -82,20 +82,20 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
-                    - githubactions 
+                    - jenkins
+                    - githubactions
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Github Actions (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Github Actions (SLSA 2)
             - required:
                 - glHost
-                - ciType  
+                - ciType
                 - glOwner
                 - hostType
               properties:
                 hostType:
-                    const: GitLab  
+                    const: GitLab
                 glOwner:
                   title: Repository Owner
                   type: string
@@ -116,18 +116,18 @@ spec:
                     - gitlabci
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Gitlab CI (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Gitlab CI (SLSA 2)
             - required:
                 - bbHost
-                - ciType  
+                - ciType
                 - bbOwner
-                - hostType   
+                - hostType
                 - workspace
                 - project
               properties:
                 hostType:
-                    const: Bitbucket  
+                    const: Bitbucket
                 bbOwner:
                   title: Repository Owner
                   type: string
@@ -140,11 +140,11 @@ spec:
                   ui:help: "Bitbucket Cloud Default"
                 workspace:
                   title: Workspace
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Workspace"
                 project:
                   title: Project
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Project"
                 ciType:
                   title: CI Provider
@@ -152,10 +152,10 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
+                    - jenkins
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2)   
+                    - Jenkins (SLSA 2)
     - title: Deployment information
       required:
         - imageRegistry
@@ -203,7 +203,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
-          
+
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
     - id: fetch-skeleton
       name: Fetch Skeleton
@@ -213,42 +213,42 @@ spec:
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Quarkus Java example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for Quarkus Java example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: src/main/docker/Dockerfile.jvm.staged
-          buildContext: .  
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          buildContext: .
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           imageName: ${{ parameters.imageName }}
           tags: '["java", "quarkus", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          hostType: ${{ parameters.hostType }} 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          defaultBranch: ${{ parameters.branch }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
     - id: fetch-ci-skeleton
       name: Fetch CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}  
+        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Quarkus Java example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for Quarkus Java example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: src/main/docker/Dockerfile.jvm.staged
           buildContext: .
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           tags: '["java", "quarkus", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }}  
+          defaultBranch: ${{ parameters.branch }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to GitHub
@@ -304,31 +304,31 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
-          argoProject: default 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          argoProject: default
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     # Fetch CI which will be in a folder ci/gitops/type
     - id: fetch-gitops-ci-skeleton
       name: Fetch Gitops CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}} 
+        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
         targetPath: gitops
         values:
           name: ${{ parameters.name }}
@@ -342,23 +342,23 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
           argoProject: default
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }}  
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }}  
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory
@@ -376,7 +376,7 @@ spec:
         allowedHosts: ['${{ parameters.ghHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.ghHost }}?owner=${{ parameters.ghOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
@@ -389,7 +389,7 @@ spec:
         allowedHosts: ['${{ parameters.glHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.glHost }}?owner=${{ parameters.glOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     - id: publish-bitbucket-gitops
@@ -401,10 +401,10 @@ spec:
         allowedHosts: ['${{ parameters.bbHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.bbHost }}?owner=${{ parameters.bbOwner }}&repo=${{ parameters.repoName }}-gitops&project=${{ parameters.project }}&workspace=${{ parameters.workspace }}
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
-                
+
     - id: wait-for-github-repository
       name: Waiting for repository availability
       action: 'debug:wait'
@@ -420,7 +420,7 @@ spec:
       name: Register Gitops
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}  
+        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
         catalogInfoPath: '/catalog-info.yaml'
     - id: create-argocd-resources
       name: Create ArgoCD Resources

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -436,9 +436,9 @@ spec:
   output:
     links:
       - title: Source Repository
-        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.remoteUrl) }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.repoContentsUrl) }}
       - title: GitOps Repository
-        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.remoteUrl) }}
+        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -4,7 +4,7 @@ kind: Template
 metadata:
   name: dotnet-basic
   title:  C# .NET - Trusted Application Pipeline
-  description: C# .Net 6.0 example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+  description: C# .Net 6.0 example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
   tags: ["net", "sscs", "sbom", "acs"]
 spec:
   type: service
@@ -36,9 +36,9 @@ spec:
               kind: [Group, User]
     - title: Application Repository Information
       required:
-        - hostType 
+        - hostType
         - repoName
-        - branch 
+        - branch
       properties:
         hostType:
           title: Host Type
@@ -60,12 +60,12 @@ spec:
           oneOf:
             - required:
                 - ghHost
-                - ciType  
+                - ciType
                 - ghOwner
                 - hostType
               properties:
                 hostType:
-                  const: GitHub   
+                  const: GitHub
                 ghOwner:
                   title: Repository Owner
                   type: string
@@ -82,20 +82,20 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
-                    - githubactions 
+                    - jenkins
+                    - githubactions
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Github Actions (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Github Actions (SLSA 2)
             - required:
                 - glHost
-                - ciType  
+                - ciType
                 - glOwner
                 - hostType
               properties:
                 hostType:
-                    const: GitLab  
+                    const: GitLab
                 glOwner:
                   title: Repository Owner
                   type: string
@@ -116,18 +116,18 @@ spec:
                     - gitlabci
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Gitlab CI (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Gitlab CI (SLSA 2)
             - required:
                 - bbHost
-                - ciType  
+                - ciType
                 - bbOwner
-                - hostType   
+                - hostType
                 - workspace
                 - project
               properties:
                 hostType:
-                    const: Bitbucket  
+                    const: Bitbucket
                 bbOwner:
                   title: Repository Owner
                   type: string
@@ -140,11 +140,11 @@ spec:
                   ui:help: "Bitbucket Cloud Default"
                 workspace:
                   title: Workspace
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Workspace"
                 project:
                   title: Project
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Project"
                 ciType:
                   title: CI Provider
@@ -152,10 +152,10 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
+                    - jenkins
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2)   
+                    - Jenkins (SLSA 2)
     - title: Deployment information
       required:
         - imageRegistry
@@ -203,7 +203,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
-          
+
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
     - id: fetch-skeleton
       name: Fetch Skeleton
@@ -213,42 +213,42 @@ spec:
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for C# .Net 6.0 example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for C# .Net 6.0 example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: docker/Dockerfile
-          buildContext: .  
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          buildContext: .
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           imageName: ${{ parameters.imageName }}
           tags: '["net", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          hostType: ${{ parameters.hostType }} 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          defaultBranch: ${{ parameters.branch }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
     - id: fetch-ci-skeleton
       name: Fetch CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}  
+        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for C# .Net 6.0 example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for C# .Net 6.0 example with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: docker/Dockerfile
           buildContext: .
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           tags: '["net", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }}  
+          defaultBranch: ${{ parameters.branch }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to GitHub
@@ -304,31 +304,31 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
-          argoProject: default 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          argoProject: default
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     # Fetch CI which will be in a folder ci/gitops/type
     - id: fetch-gitops-ci-skeleton
       name: Fetch Gitops CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}} 
+        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
         targetPath: gitops
         values:
           name: ${{ parameters.name }}
@@ -342,23 +342,23 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
           argoProject: default
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }}  
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }}  
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory
@@ -376,7 +376,7 @@ spec:
         allowedHosts: ['${{ parameters.ghHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.ghHost }}?owner=${{ parameters.ghOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
@@ -389,7 +389,7 @@ spec:
         allowedHosts: ['${{ parameters.glHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.glHost }}?owner=${{ parameters.glOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     - id: publish-bitbucket-gitops
@@ -401,10 +401,10 @@ spec:
         allowedHosts: ['${{ parameters.bbHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.bbHost }}?owner=${{ parameters.bbOwner }}&repo=${{ parameters.repoName }}-gitops&project=${{ parameters.project }}&workspace=${{ parameters.workspace }}
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
-                
+
     - id: wait-for-github-repository
       name: Waiting for repository availability
       action: 'debug:wait'
@@ -420,7 +420,7 @@ spec:
       name: Register Gitops
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}  
+        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
         catalogInfoPath: '/catalog-info.yaml'
     - id: create-argocd-resources
       name: Create ArgoCD Resources

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -4,7 +4,7 @@ kind: Template
 metadata:
   name: go
   title:  Go Runtime - Trusted Application Pipeline
-  description: Go Runtime http based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+  description: Go Runtime http based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
   tags: ["go", "sscs", "sbom", "acs"]
 spec:
   type: service
@@ -36,9 +36,9 @@ spec:
               kind: [Group, User]
     - title: Application Repository Information
       required:
-        - hostType 
+        - hostType
         - repoName
-        - branch 
+        - branch
       properties:
         hostType:
           title: Host Type
@@ -60,12 +60,12 @@ spec:
           oneOf:
             - required:
                 - ghHost
-                - ciType  
+                - ciType
                 - ghOwner
                 - hostType
               properties:
                 hostType:
-                  const: GitHub   
+                  const: GitHub
                 ghOwner:
                   title: Repository Owner
                   type: string
@@ -82,20 +82,20 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
-                    - githubactions 
+                    - jenkins
+                    - githubactions
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Github Actions (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Github Actions (SLSA 2)
             - required:
                 - glHost
-                - ciType  
+                - ciType
                 - glOwner
                 - hostType
               properties:
                 hostType:
-                    const: GitLab  
+                    const: GitLab
                 glOwner:
                   title: Repository Owner
                   type: string
@@ -116,18 +116,18 @@ spec:
                     - gitlabci
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Gitlab CI (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Gitlab CI (SLSA 2)
             - required:
                 - bbHost
-                - ciType  
+                - ciType
                 - bbOwner
-                - hostType   
+                - hostType
                 - workspace
                 - project
               properties:
                 hostType:
-                    const: Bitbucket  
+                    const: Bitbucket
                 bbOwner:
                   title: Repository Owner
                   type: string
@@ -140,11 +140,11 @@ spec:
                   ui:help: "Bitbucket Cloud Default"
                 workspace:
                   title: Workspace
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Workspace"
                 project:
                   title: Project
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Project"
                 ciType:
                   title: CI Provider
@@ -152,10 +152,10 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
+                    - jenkins
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2)   
+                    - Jenkins (SLSA 2)
     - title: Deployment information
       required:
         - imageRegistry
@@ -203,7 +203,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
-          
+
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
     - id: fetch-skeleton
       name: Fetch Skeleton
@@ -213,42 +213,42 @@ spec:
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Go Runtime http based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for Go Runtime http based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: docker/Dockerfile
-          buildContext: .  
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          buildContext: .
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           imageName: ${{ parameters.imageName }}
           tags: '["go", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          hostType: ${{ parameters.hostType }} 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          defaultBranch: ${{ parameters.branch }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
     - id: fetch-ci-skeleton
       name: Fetch CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}  
+        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Go Runtime http based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for Go Runtime http based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: docker/Dockerfile
           buildContext: .
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           tags: '["go", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }}  
+          defaultBranch: ${{ parameters.branch }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to GitHub
@@ -304,31 +304,31 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
-          argoProject: default 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          argoProject: default
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     # Fetch CI which will be in a folder ci/gitops/type
     - id: fetch-gitops-ci-skeleton
       name: Fetch Gitops CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}} 
+        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
         targetPath: gitops
         values:
           name: ${{ parameters.name }}
@@ -342,23 +342,23 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
           argoProject: default
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }}  
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }}  
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory
@@ -376,7 +376,7 @@ spec:
         allowedHosts: ['${{ parameters.ghHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.ghHost }}?owner=${{ parameters.ghOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
@@ -389,7 +389,7 @@ spec:
         allowedHosts: ['${{ parameters.glHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.glHost }}?owner=${{ parameters.glOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     - id: publish-bitbucket-gitops
@@ -401,10 +401,10 @@ spec:
         allowedHosts: ['${{ parameters.bbHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.bbHost }}?owner=${{ parameters.bbOwner }}&repo=${{ parameters.repoName }}-gitops&project=${{ parameters.project }}&workspace=${{ parameters.workspace }}
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
-                
+
     - id: wait-for-github-repository
       name: Waiting for repository availability
       action: 'debug:wait'
@@ -420,7 +420,7 @@ spec:
       name: Register Gitops
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}  
+        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
         catalogInfoPath: '/catalog-info.yaml'
     - id: create-argocd-resources
       name: Create ArgoCD Resources

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -436,9 +436,9 @@ spec:
   output:
     links:
       - title: Source Repository
-        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.remoteUrl) }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.repoContentsUrl) }}
       - title: GitOps Repository
-        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.remoteUrl) }}
+        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -436,9 +436,9 @@ spec:
   output:
     links:
       - title: Source Repository
-        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.remoteUrl) }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.repoContentsUrl) }}
       - title: GitOps Repository
-        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.remoteUrl) }}
+        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -4,7 +4,7 @@ kind: Template
 metadata:
   name: java-springboot
   title:  Spring Boot® - Trusted Application Pipeline
-  description: Spring Boot® using Maven sample HTTP/REST application based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+  description: Spring Boot® using Maven sample HTTP/REST application based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
   tags: ["java", "spring", "sscs", "sbom", "acs"]
 spec:
   type: service
@@ -36,9 +36,9 @@ spec:
               kind: [Group, User]
     - title: Application Repository Information
       required:
-        - hostType 
+        - hostType
         - repoName
-        - branch 
+        - branch
       properties:
         hostType:
           title: Host Type
@@ -60,12 +60,12 @@ spec:
           oneOf:
             - required:
                 - ghHost
-                - ciType  
+                - ciType
                 - ghOwner
                 - hostType
               properties:
                 hostType:
-                  const: GitHub   
+                  const: GitHub
                 ghOwner:
                   title: Repository Owner
                   type: string
@@ -82,20 +82,20 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
-                    - githubactions 
+                    - jenkins
+                    - githubactions
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Github Actions (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Github Actions (SLSA 2)
             - required:
                 - glHost
-                - ciType  
+                - ciType
                 - glOwner
                 - hostType
               properties:
                 hostType:
-                    const: GitLab  
+                    const: GitLab
                 glOwner:
                   title: Repository Owner
                   type: string
@@ -116,18 +116,18 @@ spec:
                     - gitlabci
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Gitlab CI (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Gitlab CI (SLSA 2)
             - required:
                 - bbHost
-                - ciType  
+                - ciType
                 - bbOwner
-                - hostType   
+                - hostType
                 - workspace
                 - project
               properties:
                 hostType:
-                    const: Bitbucket  
+                    const: Bitbucket
                 bbOwner:
                   title: Repository Owner
                   type: string
@@ -140,11 +140,11 @@ spec:
                   ui:help: "Bitbucket Cloud Default"
                 workspace:
                   title: Workspace
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Workspace"
                 project:
                   title: Project
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Project"
                 ciType:
                   title: CI Provider
@@ -152,10 +152,10 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
+                    - jenkins
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2)   
+                    - Jenkins (SLSA 2)
     - title: Deployment information
       required:
         - imageRegistry
@@ -203,7 +203,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
-          
+
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
     - id: fetch-skeleton
       name: Fetch Skeleton
@@ -213,42 +213,42 @@ spec:
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Spring Boot® using Maven sample HTTP/REST application based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for Spring Boot® using Maven sample HTTP/REST application based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: docker/Dockerfile
-          buildContext: .  
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          buildContext: .
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           imageName: ${{ parameters.imageName }}
           tags: '["java", "spring", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          hostType: ${{ parameters.hostType }} 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          defaultBranch: ${{ parameters.branch }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
     - id: fetch-ci-skeleton
       name: Fetch CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}  
+        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Spring Boot® using Maven sample HTTP/REST application based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for Spring Boot® using Maven sample HTTP/REST application based application with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: docker/Dockerfile
           buildContext: .
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           tags: '["java", "spring", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }}  
+          defaultBranch: ${{ parameters.branch }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to GitHub
@@ -304,31 +304,31 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
-          argoProject: default 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          argoProject: default
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     # Fetch CI which will be in a folder ci/gitops/type
     - id: fetch-gitops-ci-skeleton
       name: Fetch Gitops CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}} 
+        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
         targetPath: gitops
         values:
           name: ${{ parameters.name }}
@@ -342,23 +342,23 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
           argoProject: default
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }}  
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }}  
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory
@@ -376,7 +376,7 @@ spec:
         allowedHosts: ['${{ parameters.ghHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.ghHost }}?owner=${{ parameters.ghOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
@@ -389,7 +389,7 @@ spec:
         allowedHosts: ['${{ parameters.glHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.glHost }}?owner=${{ parameters.glOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     - id: publish-bitbucket-gitops
@@ -401,10 +401,10 @@ spec:
         allowedHosts: ['${{ parameters.bbHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.bbHost }}?owner=${{ parameters.bbOwner }}&repo=${{ parameters.repoName }}-gitops&project=${{ parameters.project }}&workspace=${{ parameters.workspace }}
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
-                
+
     - id: wait-for-github-repository
       name: Waiting for repository availability
       action: 'debug:wait'
@@ -420,7 +420,7 @@ spec:
       name: Register Gitops
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}  
+        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
         catalogInfoPath: '/catalog-info.yaml'
     - id: create-argocd-resources
       name: Create ArgoCD Resources

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -436,9 +436,9 @@ spec:
   output:
     links:
       - title: Source Repository
-        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.remoteUrl) }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.repoContentsUrl) }}
       - title: GitOps Repository
-        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.remoteUrl) }}
+        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -4,7 +4,7 @@ kind: Template
 metadata:
   name: nodejs
   title:  Node.js Express - Trusted Application Pipeline
-  description: Node.js+Express REST API with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+  description: Node.js+Express REST API with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
   tags: ["nodejs", "express", "ubi8", "sscs", "sbom", "acs"]
 spec:
   type: service
@@ -36,9 +36,9 @@ spec:
               kind: [Group, User]
     - title: Application Repository Information
       required:
-        - hostType 
+        - hostType
         - repoName
-        - branch 
+        - branch
       properties:
         hostType:
           title: Host Type
@@ -60,12 +60,12 @@ spec:
           oneOf:
             - required:
                 - ghHost
-                - ciType  
+                - ciType
                 - ghOwner
                 - hostType
               properties:
                 hostType:
-                  const: GitHub   
+                  const: GitHub
                 ghOwner:
                   title: Repository Owner
                   type: string
@@ -82,20 +82,20 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
-                    - githubactions 
+                    - jenkins
+                    - githubactions
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Github Actions (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Github Actions (SLSA 2)
             - required:
                 - glHost
-                - ciType  
+                - ciType
                 - glOwner
                 - hostType
               properties:
                 hostType:
-                    const: GitLab  
+                    const: GitLab
                 glOwner:
                   title: Repository Owner
                   type: string
@@ -116,18 +116,18 @@ spec:
                     - gitlabci
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Gitlab CI (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Gitlab CI (SLSA 2)
             - required:
                 - bbHost
-                - ciType  
+                - ciType
                 - bbOwner
-                - hostType   
+                - hostType
                 - workspace
                 - project
               properties:
                 hostType:
-                    const: Bitbucket  
+                    const: Bitbucket
                 bbOwner:
                   title: Repository Owner
                   type: string
@@ -140,11 +140,11 @@ spec:
                   ui:help: "Bitbucket Cloud Default"
                 workspace:
                   title: Workspace
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Workspace"
                 project:
                   title: Project
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Project"
                 ciType:
                   title: CI Provider
@@ -152,10 +152,10 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
+                    - jenkins
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2)   
+                    - Jenkins (SLSA 2)
     - title: Deployment information
       required:
         - imageRegistry
@@ -203,7 +203,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
-          
+
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
     - id: fetch-skeleton
       name: Fetch Skeleton
@@ -213,42 +213,42 @@ spec:
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Node.js+Express REST API with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for Node.js+Express REST API with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: Dockerfile
-          buildContext: .  
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          buildContext: .
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           imageName: ${{ parameters.imageName }}
           tags: '["nodejs", "express", "ubi8", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          hostType: ${{ parameters.hostType }} 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          defaultBranch: ${{ parameters.branch }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
     - id: fetch-ci-skeleton
       name: Fetch CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}  
+        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Node.js+Express REST API with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment 
+          description: Secure Supply Chain Example for Node.js+Express REST API with advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures,  attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment
           dockerfile: Dockerfile
           buildContext: .
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           tags: '["nodejs", "express", "ubi8", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }}  
+          defaultBranch: ${{ parameters.branch }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to GitHub
@@ -304,31 +304,31 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 3001
           argoNS: rhtap-gitops
-          argoProject: default 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          argoProject: default
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     # Fetch CI which will be in a folder ci/gitops/type
     - id: fetch-gitops-ci-skeleton
       name: Fetch Gitops CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}} 
+        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
         targetPath: gitops
         values:
           name: ${{ parameters.name }}
@@ -342,23 +342,23 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 3001
           argoNS: rhtap-gitops
           argoProject: default
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }}  
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }}  
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory
@@ -376,7 +376,7 @@ spec:
         allowedHosts: ['${{ parameters.ghHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.ghHost }}?owner=${{ parameters.ghOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
@@ -389,7 +389,7 @@ spec:
         allowedHosts: ['${{ parameters.glHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.glHost }}?owner=${{ parameters.glOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     - id: publish-bitbucket-gitops
@@ -401,10 +401,10 @@ spec:
         allowedHosts: ['${{ parameters.bbHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.bbHost }}?owner=${{ parameters.bbOwner }}&repo=${{ parameters.repoName }}-gitops&project=${{ parameters.project }}&workspace=${{ parameters.workspace }}
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
-                
+
     - id: wait-for-github-repository
       name: Waiting for repository availability
       action: 'debug:wait'
@@ -420,7 +420,7 @@ spec:
       name: Register Gitops
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}  
+        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
         catalogInfoPath: '/catalog-info.yaml'
     - id: create-argocd-resources
       name: Create ArgoCD Resources

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -436,9 +436,9 @@ spec:
   output:
     links:
       - title: Source Repository
-        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.remoteUrl) }}
+        url: ${{ steps['publish-github'].output.remoteUrl if steps['publish-github'].output else (steps['publish-gitlab'].output.remoteUrl  if steps['publish-gitlab'].output else steps['publish-bitbucket'].output.repoContentsUrl) }}
       - title: GitOps Repository
-        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.remoteUrl) }}
+        url: ${{ steps['publish-github-gitops'].output.remoteUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.remoteUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -4,7 +4,7 @@ kind: Template
 metadata:
   name: python
   title:  Python - Trusted Application Pipeline
-  description: Python is an interpreted,  object-oriented, high-level programming language with dynamic semantics. This sample demonstrates software supply chain security functionalty using an advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures, attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment. 
+  description: Python is an interpreted,  object-oriented, high-level programming language with dynamic semantics. This sample demonstrates software supply chain security functionalty using an advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures, attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment.
   tags: ["python", "pip", "flask", "sscs", "sbom", "acs"]
 spec:
   type: service
@@ -36,9 +36,9 @@ spec:
               kind: [Group, User]
     - title: Application Repository Information
       required:
-        - hostType 
+        - hostType
         - repoName
-        - branch 
+        - branch
       properties:
         hostType:
           title: Host Type
@@ -60,12 +60,12 @@ spec:
           oneOf:
             - required:
                 - ghHost
-                - ciType  
+                - ciType
                 - ghOwner
                 - hostType
               properties:
                 hostType:
-                  const: GitHub   
+                  const: GitHub
                 ghOwner:
                   title: Repository Owner
                   type: string
@@ -82,20 +82,20 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
-                    - githubactions 
+                    - jenkins
+                    - githubactions
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Github Actions (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Github Actions (SLSA 2)
             - required:
                 - glHost
-                - ciType  
+                - ciType
                 - glOwner
                 - hostType
               properties:
                 hostType:
-                    const: GitLab  
+                    const: GitLab
                 glOwner:
                   title: Repository Owner
                   type: string
@@ -116,18 +116,18 @@ spec:
                     - gitlabci
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2) 
-                    - Gitlab CI (SLSA 2) 
+                    - Jenkins (SLSA 2)
+                    - Gitlab CI (SLSA 2)
             - required:
                 - bbHost
-                - ciType  
+                - ciType
                 - bbOwner
-                - hostType   
+                - hostType
                 - workspace
                 - project
               properties:
                 hostType:
-                    const: Bitbucket  
+                    const: Bitbucket
                 bbOwner:
                   title: Repository Owner
                   type: string
@@ -140,11 +140,11 @@ spec:
                   ui:help: "Bitbucket Cloud Default"
                 workspace:
                   title: Workspace
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Workspace"
                 project:
                   title: Project
-                  type: string 
+                  type: string
                   ui:help: "Bitbucket Project"
                 ciType:
                   title: CI Provider
@@ -152,10 +152,10 @@ spec:
                   default: tekton
                   enum:
                     - tekton
-                    - jenkins 
+                    - jenkins
                   enumNames:
                     - Tekton (SLSA 3)
-                    - Jenkins (SLSA 2)   
+                    - Jenkins (SLSA 2)
     - title: Deployment information
       required:
         - imageRegistry
@@ -203,7 +203,7 @@ spec:
           namespace: ${{ parameters.namespace }}
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
-          
+
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
     - id: fetch-skeleton
       name: Fetch Skeleton
@@ -213,42 +213,42 @@ spec:
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Python is an interpreted,  object-oriented, high-level programming language with dynamic semantics. This sample demonstrates software supply chain security functionalty using an advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures, attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment. 
+          description: Secure Supply Chain Example for Python is an interpreted,  object-oriented, high-level programming language with dynamic semantics. This sample demonstrates software supply chain security functionalty using an advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures, attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment.
           dockerfile: docker/Dockerfile
-          buildContext: .  
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          buildContext: .
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           imageName: ${{ parameters.imageName }}
           tags: '["python", "pip", "flask", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          hostType: ${{ parameters.hostType }} 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          defaultBranch: ${{ parameters.branch }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
     - id: fetch-ci-skeleton
       name: Fetch CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}  
+        url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
         values:
           name: ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          description: Secure Supply Chain Example for Python is an interpreted,  object-oriented, high-level programming language with dynamic semantics. This sample demonstrates software supply chain security functionalty using an advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures, attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment. 
+          description: Secure Supply Chain Example for Python is an interpreted,  object-oriented, high-level programming language with dynamic semantics. This sample demonstrates software supply chain security functionalty using an advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures, attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment.
           dockerfile: docker/Dockerfile
           buildContext: .
-          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}} 
+          gitopsSecretName: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           image: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           tags: '["python", "pip", "flask", "sscs", "sbom", "acs"]'
-          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops  
-          owner: ${{ parameters.owner }} 
+          repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          defaultBranch: ${{ parameters.branch }}  
+          defaultBranch: ${{ parameters.branch }}
     # This action creates a new GitHub repository and publishes the files in the workspace directory to the repository.
     - id: publish-github
       name: Publish Repository to GitHub
@@ -304,31 +304,31 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
-          argoProject: default 
-          ciType: ${{ parameters.ciType }} 
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops         
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }} 
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }} 
+          argoProject: default
+          ciType: ${{ parameters.ciType }}
+          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     # Fetch CI which will be in a folder ci/gitops/type
     - id: fetch-gitops-ci-skeleton
       name: Fetch Gitops CI Components
       action: fetch:template
       input:
-        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}} 
+        url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
         targetPath: gitops
         values:
           name: ${{ parameters.name }}
@@ -342,23 +342,23 @@ spec:
           srcRepoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
           argoComponent: './components/${{ parameters.name }}/overlays/development'
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
-          owner: ${{ parameters.owner }} 
+          owner: ${{ parameters.owner }}
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           port: 8081
           argoNS: rhtap-gitops
           argoProject: default
-          hostType: ${{ parameters.hostType }} 
-          username: ${{ parameters.bbOwner }} 
-          secretRef: ${{ parameters.hostType != 'GitHub' }}  
-          isTekton: ${{ parameters.ciType === 'tekton' }} 
-          isJenkins: ${{ parameters.ciType === 'jenkins' }}  
+          hostType: ${{ parameters.hostType }}
+          username: ${{ parameters.bbOwner }}
+          secretRef: ${{ parameters.hostType != 'GitHub' }}
+          isTekton: ${{ parameters.ciType === 'tekton' }}
+          isJenkins: ${{ parameters.ciType === 'jenkins' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret
           webhookSecretKey: webhook.secret
-          defaultBranch: ${{ parameters.branch }} 
+          defaultBranch: ${{ parameters.branch }}
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory
@@ -376,7 +376,7 @@ spec:
         allowedHosts: ['${{ parameters.ghHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.ghHost }}?owner=${{ parameters.ghOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
@@ -389,7 +389,7 @@ spec:
         allowedHosts: ['${{ parameters.glHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.glHost }}?owner=${{ parameters.glOwner }}&repo=${{ parameters.repoName }}-gitops
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
     - id: publish-bitbucket-gitops
@@ -401,10 +401,10 @@ spec:
         allowedHosts: ['${{ parameters.bbHost }}']
         description: This is GitOps repository for ${{ parameters.name }}
         repoUrl:  ${{ parameters.bbHost }}?owner=${{ parameters.bbOwner }}&repo=${{ parameters.repoName }}-gitops&project=${{ parameters.project }}&workspace=${{ parameters.workspace }}
-        defaultBranch: ${{ parameters.branch }} 
+        defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
-                
+
     - id: wait-for-github-repository
       name: Waiting for repository availability
       action: 'debug:wait'
@@ -420,7 +420,7 @@ spec:
       name: Register Gitops
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}  
+        repoContentsUrl: ${{ steps['publish-github-gitops'].output.repoContentsUrl if steps['publish-github-gitops'].output else (steps['publish-gitlab-gitops'].output.repoContentsUrl  if steps['publish-gitlab-gitops'].output else steps['publish-bitbucket-gitops'].output.repoContentsUrl) }}
         catalogInfoPath: '/catalog-info.yaml'
     - id: create-argocd-resources
       name: Create ArgoCD Resources


### PR DESCRIPTION
For bitbucket, the Source/GitOps Repository template output links is populated from the `remoteUrl` output from
the `publish-bitbucket-gitops` task which uses the `publish:bitbucketCloud` action.

[This](https://github.com/backstage/backstage/blob/00292047ed0b3cc8659b8075c21281bd694ed911/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.ts#L67-L89) is how that plugin determines the value of `remoteUrl`.

The value is retrieved directly from the BitBucket's API. We can replicate what the plugin is doing with curl and jq:

```
$ curl -s 'https://api.bitbucket.org/2.0/repositories/rhtap-test/bitbucket-tekton-quay-dotnet-14x' | jq -r '.links.clone[] | select(.name == "https") | .href'
https://bitbucket.org/rhtap-test/bitbucket-tekton-quay-dotnet-14x.git
```

Notice how this link is under the `.link.clone` section of the response. This URL works just fine for cloning (as it is intended). It does not, however, work for accessing the repo via a web browser.

For that, there's a different URL:

```
$ curl -s 'https://api.bitbucket.org/2.0/repositories/rhtap-test/bitbucket-tekton-quay-dotnet-14x' | jq -r '.links.html.href'
https://bitbucket.org/rhtap-test/bitbucket-tekton-quay-dotnet-14x
```

And that URL, of course, works just fine.

This commit changes the application creation template to use the [repoContentsUrl](https://github.com/backstage/backstage/blob/00292047ed0b3cc8659b8075c21281bd694ed911/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.ts#L93) for this purpose.

This change also removes some of those silly trailing white spaces (in a separate commit.)