### PR TITLE
Do not render gitops GH workflows

### DIFF
--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -329,6 +329,8 @@ spec:
       action: fetch:template
       input:
         url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
+        copyWithoutRender:
+          - .github/workflows/*
         targetPath: gitops
         values:
           name: ${{ parameters.name }}

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -329,6 +329,8 @@ spec:
       action: fetch:template
       input:
         url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
+        copyWithoutRender:
+          - .github/workflows/*
         targetPath: gitops
         values:
           name: ${{ parameters.name }}

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -329,6 +329,8 @@ spec:
       action: fetch:template
       input:
         url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
+        copyWithoutRender:
+          - .github/workflows/*
         targetPath: gitops
         values:
           name: ${{ parameters.name }}

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -329,6 +329,8 @@ spec:
       action: fetch:template
       input:
         url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
+        copyWithoutRender:
+          - .github/workflows/*
         targetPath: gitops
         values:
           name: ${{ parameters.name }}

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -329,6 +329,8 @@ spec:
       action: fetch:template
       input:
         url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
+        copyWithoutRender:
+          - .github/workflows/*
         targetPath: gitops
         values:
           name: ${{ parameters.name }}

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -329,6 +329,8 @@ spec:
       action: fetch:template
       input:
         url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
+        copyWithoutRender:
+          - .github/workflows/*
         targetPath: gitops
         values:
           name: ${{ parameters.name }}

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -329,6 +329,8 @@ spec:
       action: fetch:template
       input:
         url: ../../skeleton/ci/gitops-template/${{ parameters.ciType}}
+        copyWithoutRender:
+          - .github/workflows/*
         targetPath: gitops
         values:
           name: ${{ parameters.name }}


### PR DESCRIPTION
The GitHub Workflows used in the app and the gitops repos contain variable placeholders that must not be resolved when creating the component. Instead, these should be resolved by GitHub itself when the workflow runs.

For example, the following should be copied as is without rendering the variables:

```
IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
```

This commit applies the same `copyWithoutRender` directive to the gitops repo that is already applied to the app repo.

Ref: RHTAP-4047