### PR TITLE
feat: Use imagePullSecrets in deployment

### DIFF
--- a/skeleton/gitops-template/components/http/base/deployment.yaml
+++ b/skeleton/gitops-template/components/http/base/deployment.yaml
@@ -49,4 +49,5 @@ spec:
         env:
         - name: GIT_REPO
           value: ${{ values.repoURL }}
-
+      imagePullSecrets:
+        - name: rhtap-image-registry-auth


### PR DESCRIPTION
This allows for a simplified and more robust management of the secret(s) needed to pull images to run the workloads.

It is a preferable solution to linking the secret to a specific ServiceAccount.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED