### PR TITLE
fix: increase gitops sync timeout

### DIFF
--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -348,7 +348,7 @@ spec:
       action: 'debug:wait'
       if: ${{ parameters.ciType === 'tekton' }}
       input:
-        seconds: 3
+        seconds: 15
 
     #
     # Create source repository

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -348,7 +348,7 @@ spec:
       action: 'debug:wait'
       if: ${{ parameters.ciType === 'tekton' }}
       input:
-        seconds: 3
+        seconds: 15
 
     #
     # Create source repository

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -348,7 +348,7 @@ spec:
       action: 'debug:wait'
       if: ${{ parameters.ciType === 'tekton' }}
       input:
-        seconds: 3
+        seconds: 15
 
     #
     # Create source repository

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -348,7 +348,7 @@ spec:
       action: 'debug:wait'
       if: ${{ parameters.ciType === 'tekton' }}
       input:
-        seconds: 3
+        seconds: 15
 
     #
     # Create source repository

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -348,7 +348,7 @@ spec:
       action: 'debug:wait'
       if: ${{ parameters.ciType === 'tekton' }}
       input:
-        seconds: 3
+        seconds: 15
 
     #
     # Create source repository

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -348,7 +348,7 @@ spec:
       action: 'debug:wait'
       if: ${{ parameters.ciType === 'tekton' }}
       input:
-        seconds: 3
+        seconds: 15
 
     #
     # Create source repository

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -348,7 +348,7 @@ spec:
       action: 'debug:wait'
       if: ${{ parameters.ciType === 'tekton' }}
       input:
-        seconds: 3
+        seconds: 15
 
     #
     # Create source repository


### PR DESCRIPTION
The initial value was too aggressive. My experience is that it usually takes around 10s, so I set the value to 15.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED