### PR TITLE
RHDHPAI-619: Add Azure Pipelines CI Type

### DIFF
--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -83,10 +83,12 @@ spec:
                   enum:
                     - tekton
                     - jenkins
+                    - azure
                     - githubactions
                   enumNames:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
+                    - Azure Pipelines (SLSA 2)
                     - Github Actions (SLSA 2)
             - required:
                 - glHost
@@ -113,10 +115,12 @@ spec:
                   enum:
                     - tekton
                     - jenkins
+                    - azure
                     - gitlabci
                   enumNames:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
+                    - Azure Pipelines (SLSA 2)
                     - Gitlab CI (SLSA 2)
             - required:
                 - bbHost
@@ -153,9 +157,11 @@ spec:
                   enum:
                     - tekton
                     - jenkins
+                    - azure
                   enumNames:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
+                    - Azure Pipelines (SLSA 2)
     - title: Deployment information
       required:
         - imageRegistry


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHDHPAI-619

## Adds Azure Pipelines CI Type

Adds the Azure Pipelines option to the CI Type enum under all possible host types of the skeleton template and software templates. Allows users of Software Templates to select to run their pipelines on Azure.
