### PR TITLE
RHDHPAI-621: Add annotations to GitOps and source skeletons

### DIFF
--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -268,7 +268,8 @@ spec:
           argoNS: ${ARGOCD__DEFAULT__NAMESPACE}
           argoProject: ${ARGOCD__DEFAULT__PROJECT}
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}-gitops
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
@@ -430,7 +431,8 @@ spec:
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'

--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -108,7 +108,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
                     - properties:
                         ciType:
                           const: githubactions
@@ -200,7 +200,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry

--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -90,6 +90,28 @@ spec:
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
                     - Github Actions (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
+                    - properties:
+                        ciType:
+                          const: githubactions
             - required:
                 - glHost
                 - ciType
@@ -160,6 +182,25 @@ spec:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry
@@ -228,6 +269,7 @@ spec:
           argoProject: ${ARGOCD__DEFAULT__PROJECT}
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
           secretRef: ${{ parameters.hostType != 'GitHub' }}
@@ -389,6 +431,7 @@ spec:
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           defaultBranch: ${{ parameters.branch }}

--- a/skeleton/gitops-template/catalog-info.yaml
+++ b/skeleton/gitops-template/catalog-info.yaml
@@ -26,6 +26,7 @@ metadata:
   {%- endif %}   
   {%- if values.ciType == 'azure' %}
     dev.azure.com/project-repo: ${{ values.gitRepoSlug }}
+    dev.azure.com/project: ${{ values.azureProject }}
   {%- endif %}
 spec:
   type: gitops

--- a/skeleton/gitops-template/catalog-info.yaml
+++ b/skeleton/gitops-template/catalog-info.yaml
@@ -19,13 +19,13 @@ metadata:
     jenkins.io/job-full-name: ${{ values.appName }} 
   {%- endif %} 
   {%- if values.ciType == 'githubactions' %} 
-    github.com/project-slug: ${{ values.gitRepoSlug }} 
+    github.com/project-slug: ${{ values.gitRepoOwner }}/${{ values.gitRepoName }} 
   {%- endif %} 
   {%- if values.ciType == 'gitlabci' %} 
-    gitlab.com/project-slug: '${{ values.gitRepoSlug }}'
+    gitlab.com/project-slug: '${{ values.gitRepoOwner }}/${{ values.gitRepoName }}'
   {%- endif %}   
   {%- if values.ciType == 'azure' %}
-    dev.azure.com/project-repo: ${{ values.gitRepoSlug }}
+    dev.azure.com/project-repo: ${{ values.gitRepoOwner }}/${{ values.gitRepoName }}
     dev.azure.com/project: ${{ values.azureProject }}
   {%- endif %}
 spec:

--- a/skeleton/gitops-template/catalog-info.yaml
+++ b/skeleton/gitops-template/catalog-info.yaml
@@ -24,6 +24,9 @@ metadata:
   {%- if values.ciType == 'gitlabci' %} 
     gitlab.com/project-slug: '${{ values.gitRepoSlug }}'
   {%- endif %}   
+  {%- if values.ciType == 'azure' %}
+    dev.azure.com/project-repo: ${{ values.gitRepoSlug }}
+  {%- endif %}
 spec:
   type: gitops
   owner: ${{ values.owner }} 

--- a/skeleton/gitops-template/catalog-info.yaml
+++ b/skeleton/gitops-template/catalog-info.yaml
@@ -27,6 +27,7 @@ metadata:
   {%- if values.ciType == 'azure' %}
     dev.azure.com/project-repo: ${{ values.gitRepoOwner }}/${{ values.gitRepoName }}
     dev.azure.com/project: ${{ values.azureProject }}
+    dev.azure.com/build-definition: ${{ values.gitRepoOwner }}.${{ values.gitRepoName }}
   {%- endif %}
 spec:
   type: gitops

--- a/skeleton/source-repo/catalog-info.yaml
+++ b/skeleton/source-repo/catalog-info.yaml
@@ -21,6 +21,7 @@ metadata:
   {%- endif %}    
   {%- if values.ciType == 'azure' %}
     dev.azure.com/project-repo: ${{ values.gitRepoSlug }}
+    dev.azure.com/project: ${{ values.azureProject }}
   {%- endif %}
   {%- if values.ciType == 'tekton' %} 
     janus-idp.io/tekton: ${{ values.name }} 

--- a/skeleton/source-repo/catalog-info.yaml
+++ b/skeleton/source-repo/catalog-info.yaml
@@ -19,6 +19,9 @@ metadata:
   {%- if values.ciType == 'gitlabci' %} 
     gitlab.com/project-slug: '${{ values.gitRepoSlug }}'
   {%- endif %}    
+  {%- if values.ciType == 'azure' %}
+    dev.azure.com/project-repo: ${{ values.gitRepoSlug }}
+  {%- endif %}
   {%- if values.ciType == 'tekton' %} 
     janus-idp.io/tekton: ${{ values.name }} 
   {%- endif %} 

--- a/skeleton/source-repo/catalog-info.yaml
+++ b/skeleton/source-repo/catalog-info.yaml
@@ -14,13 +14,13 @@ metadata:
     backstage.io/kubernetes-id: ${{ values.name }} 
     backstage.io/techdocs-ref: dir:.  
   {%- if values.ciType == 'githubactions' %} 
-    github.com/project-slug: ${{ values.gitRepoSlug }} 
+    github.com/project-slug: ${{ values.gitRepoOwner }}/${{ values.gitRepoName }} 
   {%- endif %} 
   {%- if values.ciType == 'gitlabci' %} 
-    gitlab.com/project-slug: '${{ values.gitRepoSlug }}'
+    gitlab.com/project-slug: '${{ values.gitRepoOwner }}/${{ values.gitRepoName }}'
   {%- endif %}    
   {%- if values.ciType == 'azure' %}
-    dev.azure.com/project-repo: ${{ values.gitRepoSlug }}
+    dev.azure.com/project-repo: ${{ values.gitRepoOwner }}/${{ values.gitRepoName }}
     dev.azure.com/project: ${{ values.azureProject }}
   {%- endif %}
   {%- if values.ciType == 'tekton' %} 

--- a/skeleton/source-repo/catalog-info.yaml
+++ b/skeleton/source-repo/catalog-info.yaml
@@ -22,6 +22,7 @@ metadata:
   {%- if values.ciType == 'azure' %}
     dev.azure.com/project-repo: ${{ values.gitRepoOwner }}/${{ values.gitRepoName }}
     dev.azure.com/project: ${{ values.azureProject }}
+    dev.azure.com/build-definition: ${{ values.gitRepoOwner }}.${{ values.gitRepoName }}
   {%- endif %}
   {%- if values.ciType == 'tekton' %} 
     janus-idp.io/tekton: ${{ values.name }} 

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -90,6 +90,28 @@ spec:
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
                     - Github Actions (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
+                    - properties:
+                        ciType:
+                          const: githubactions
             - required:
                 - glHost
                 - ciType
@@ -160,6 +182,25 @@ spec:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry
@@ -228,6 +269,7 @@ spec:
           argoProject: default
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
           secretRef: ${{ parameters.hostType != 'GitHub' }}
@@ -389,6 +431,7 @@ spec:
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -268,7 +268,8 @@ spec:
           argoNS: rhtap-gitops
           argoProject: default
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}-gitops
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
@@ -430,7 +431,8 @@ spec:
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -108,7 +108,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
                     - properties:
                         ciType:
                           const: githubactions
@@ -200,7 +200,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -90,6 +90,28 @@ spec:
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
                     - Github Actions (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
+                    - properties:
+                        ciType:
+                          const: githubactions
             - required:
                 - glHost
                 - ciType
@@ -160,6 +182,25 @@ spec:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry
@@ -228,6 +269,7 @@ spec:
           argoProject: default
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
           secretRef: ${{ parameters.hostType != 'GitHub' }}
@@ -389,6 +431,7 @@ spec:
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -268,7 +268,8 @@ spec:
           argoNS: rhtap-gitops
           argoProject: default
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}-gitops
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
@@ -430,7 +431,8 @@ spec:
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -108,7 +108,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
                     - properties:
                         ciType:
                           const: githubactions
@@ -200,7 +200,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -90,6 +90,28 @@ spec:
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
                     - Github Actions (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
+                    - properties:
+                        ciType:
+                          const: githubactions
             - required:
                 - glHost
                 - ciType
@@ -160,6 +182,25 @@ spec:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry
@@ -228,6 +269,7 @@ spec:
           argoProject: default
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
           secretRef: ${{ parameters.hostType != 'GitHub' }}
@@ -389,6 +431,7 @@ spec:
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -268,7 +268,8 @@ spec:
           argoNS: rhtap-gitops
           argoProject: default
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}-gitops
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
@@ -430,7 +431,8 @@ spec:
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -108,7 +108,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
                     - properties:
                         ciType:
                           const: githubactions
@@ -200,7 +200,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -90,6 +90,28 @@ spec:
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
                     - Github Actions (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
+                    - properties:
+                        ciType:
+                          const: githubactions
             - required:
                 - glHost
                 - ciType
@@ -160,6 +182,25 @@ spec:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry
@@ -228,6 +269,7 @@ spec:
           argoProject: default
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
           secretRef: ${{ parameters.hostType != 'GitHub' }}
@@ -389,6 +431,7 @@ spec:
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -268,7 +268,8 @@ spec:
           argoNS: rhtap-gitops
           argoProject: default
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}-gitops
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
@@ -430,7 +431,8 @@ spec:
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -108,7 +108,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
                     - properties:
                         ciType:
                           const: githubactions
@@ -200,7 +200,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -90,6 +90,28 @@ spec:
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
                     - Github Actions (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
+                    - properties:
+                        ciType:
+                          const: githubactions
             - required:
                 - glHost
                 - ciType
@@ -160,6 +182,25 @@ spec:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry
@@ -228,6 +269,7 @@ spec:
           argoProject: default
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
           secretRef: ${{ parameters.hostType != 'GitHub' }}
@@ -389,6 +431,7 @@ spec:
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -268,7 +268,8 @@ spec:
           argoNS: rhtap-gitops
           argoProject: default
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}-gitops
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
@@ -430,7 +431,8 @@ spec:
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -108,7 +108,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
                     - properties:
                         ciType:
                           const: githubactions
@@ -200,7 +200,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -90,6 +90,28 @@ spec:
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
                     - Github Actions (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
+                    - properties:
+                        ciType:
+                          const: githubactions
             - required:
                 - glHost
                 - ciType
@@ -160,6 +182,25 @@ spec:
                     - Tekton (SLSA 3)
                     - Jenkins (SLSA 2)
                     - Azure Pipelines (SLSA 2)
+              dependencies:
+                ciType:
+                  oneOf:
+                    - properties:
+                        ciType:
+                          const: tekton
+                    - properties:
+                        ciType:
+                          const: jenkins
+                    - required: 
+                        - azureProject
+                        - ciType
+                      properties:
+                        ciType:
+                          const: azure
+                        azureProject:
+                          title: Azure Project
+                          type: string
+                          ui:help: The project the run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry
@@ -228,6 +269,7 @@ spec:
           argoProject: default
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
           secretRef: ${{ parameters.hostType != 'GitHub' }}
@@ -389,6 +431,7 @@ spec:
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
           gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           defaultBranch: ${{ parameters.branch }}

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -268,7 +268,8 @@ spec:
           argoNS: rhtap-gitops
           argoProject: default
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}-gitops
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           hostType: ${{ parameters.hostType }}
           username: ${{ parameters.bbOwner }}
@@ -430,7 +431,8 @@ spec:
           repoURL: https://${{ parameters.ghHost if parameters.hostType === 'GitHub' else (parameters.glHost if parameters.hostType === 'GitLab' else parameters.bbHost)}}/${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}-gitops
           hostType: ${{ parameters.hostType }}
           ciType: ${{ parameters.ciType }}
-          gitRepoSlug: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}/${{ parameters.repoName }}
+          gitRepoOwner: ${{ parameters.workspace if parameters.hostType === 'Bitbucket' else (parameters.ghOwner if parameters.hostType === 'GitHub' else parameters.glOwner)  }}
+          gitRepoName: ${{ parameters.repoName }}
           azureProject: ${{ parameters.azureProject if parameters.ciType === 'azure' else '' }}
           owner: ${{ parameters.owner }}
           repoSlug: '${{ parameters.imageOrg }}/${{ parameters.imageName }}'

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -108,7 +108,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
                     - properties:
                         ciType:
                           const: githubactions
@@ -200,7 +200,7 @@ spec:
                         azureProject:
                           title: Azure Project
                           type: string
-                          ui:help: The project the run the pipelines under
+                          ui:help: The project to run the pipelines under
     - title: Deployment information
       required:
         - imageRegistry


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHDHPAI-621

## Adds Azure Annotation to Catalog Info

Adds `dev.azure.com/project-repo`, `dev.azure.com/project`, and `dev.azure.com/build-definition` annotations within the GitOps Resource and Component `catalog-info.yaml` files under the skeleton template, with the condition that the CI Type is set to use Azure Pipelines to set this annotation in the created resources.

## Adds Azure Project template parameter

Adds Azure Project parameter to prompt user for target Azure Project under tied Azure host and organization set in the installer to run pipelines under. This only appears and is required if Azure CI type is selected.

## Split `values.gitRepoSlug` into `values.gitRepoOwner` and `values.gitRepoName`

Due to the name format of the expected build definition being `<repo-owner>.<repo-name>` rather than the current `gitRepoSlug` format of `<repo-owner>/<repo-name>` it makes sense to pass these value individually then format under the skeletons.

## Reviewer Notes

**Review changes only**

Same result should be expected as #120 only with the `dev.azure.com/project-repo` annotation added to the resource and component.

**Review with in development pipeline resources**

**Note:** At the time (March 31st, 2025) of writing the CI build pipelines fails with the current CI build changes.

Follow the steps to make changes that would allow the testing of these changes and #120 changes with a connected Azure pipelines environment (**this part is not yet delivered and therefore could be subject to change**), skip to step 7 to use my [test branch](https://github.com/michael-valdron/tssc-sample-templates/tree/test-azure) of this PR branch:
1. Clone the fork of [tssc-dev-multi-ci:azure-gitops-template](https://github.com/tnevrlka/tssc-dev-multi-ci/tree/azure-gitops-template) with the latest azure CI build changes **this content could be subject to change**
2. Clone both my PR branch of [tssc-sample-templates](https://github.com/michael-valdron/tssc-sample-templates/tree/azure-ci-annotations) and a fork of [tssc-sample-jenkins](https://github.com/redhat-appstudio/tssc-sample-jenkins) into `../tssc-sample-templates` and `../tssc-sample-jenkins` respectively
3. Under your local copy of the [tssc-dev-multi-ci:azure-gitops-template](https://github.com/tnevrlka/tssc-dev-multi-ci/tree/azure-gitops-template) fork, run `bash ./hack/copy-to-tssc-templates`
4. Change into `../tssc-sample-templates`, create a new branch `git checkout -b test-azure` and commit all changes done by previous step
5. Add your fork remote of [tssc-sample-templates](https://github.com/redhat-appstudio/tssc-sample-templates): `git remote add <your-remote> <remote-url>` 
6. Push the new branch into your remote fork: `git push -u <your-remote> test-azure`
7. Using [`rhtap-cli`](https://github.com/redhat-appstudio/rhtap-cli), use a copy of their [config.yaml](https://github.com/redhat-appstudio/rhtap-cli/blob/main/installer/config.yaml) to run `rhtap-cli deploy --config config.yaml` with the following changes:
    1. `rhtapCLI.features.redHatDeveloperHub.catalogURL` is set to the URL of your target testing branch `test-azure` of [tssc-sample-templates](https://github.com/redhat-appstudio/tssc-sample-templates)
    2. **Optional, if you want to use quay.io instead of provided or your cluster is using self signed cert** `rhtapCLI.features.redHatQuay.enabled` is set to `false`
8. Once deployed select one of the templates to create a component with run through steps and set CI Type to Azure Pipelines as before, fill in your target project name into the additional field that appears before it
9. Once created you will need to review all variables under the build resources, find all `azure-pipelines.yaml` files
10. Under Pipelines/Library within the Azure Project, create a variable group with each of these variables set from the values from the RHTAP install
![image](https://github.com/user-attachments/assets/c6b99cbe-21f1-4d59-b9e8-1c491c41cc19)
11. Under this new group specify all required variables
    1. `COSIGN_*` all found under `rhtap-tas/fulcio-cert-trusted-artifact-signerprgvh`
    2. `GITOPS_AUTH_PASSWORD` found as `password` under one of the following
        1. `rhtap-app-ci/gitops-auth-secret` if GitHub SCM
        2. `rhtap-app-ci/bitbucket-auth-secret` if BitBucket SCM
    3. `IMAGE_REGISTRY_PASSWORD` & `QUAY_IO_CREDS_PSW` use encrypted password when generating a password under your quay.io account
    4. `ROX_API_TOKEN` found under `rhtap-app-ci/rox-api-token`
    5. `TRUSTIFICATION_OIDC_CLIENT_SECRET` found under rhtap-app-ci/tpa-secret`
![image](https://github.com/user-attachments/assets/86ba3490-ff3f-4ca4-854f-a7150cfb5f9e)
12. Under Pipelines/Pipelines, create new a pipeline with selected SCM (GitHub or BitBucket)
13. Grant access to SCM account and RHTAP organization
14. Find gitops repository of component and select it
15. Under review click the drop down next to run and click save
16. Repeat steps 12-15 for the source repository of component
17. Back to Pipelines/Library, select pipeline permissions and add both repository pipelines added in steps 12-16
![Screenshot from 2025-03-31 17-44-46](https://github.com/user-attachments/assets/d19f59a1-ada1-4cf3-8407-7d90388bc25b)
18. Back to Pipelines/Pipelines. find gitops pipeline and run it
19. When the run displays "This pipeline needs permission to access a resource before this run can continue" click view then permit run
![Screenshot from 2025-03-31 17-52-17](https://github.com/user-attachments/assets/f4299a34-ef7b-41a1-a7b0-624b2e482267)
20. Repeat steps 18-19 for source pipeline