### PR TITLE
Add Azure Pipelines CI to templates

### DIFF
--- a/skeleton/ci/gitops-template/azure/azure-pipelines.yml
+++ b/skeleton/ci/gitops-template/azure/azure-pipelines.yml
@@ -1,0 +1,41 @@
+# Generated from templates/gitops-template/azure-pipelines.yml.njk. Do not edit directly.
+
+trigger:
+- main
+
+pool:
+  name: resourcehub
+
+container:
+  image: quay.io/redhat-appstudio/rhtap-task-runner:latest
+  options: --privileged
+
+steps:
+  - bash: |
+      echo "• gather-deploy-images"
+      bash /work/rhtap/gather-deploy-images.sh
+      echo "• verify-enterprise-contract"
+      bash /work/rhtap/verify-enterprise-contract.sh
+    name: Verify_ec
+    env:
+      TRUSTIFICATION_OIDC_CLIENT_SECRET: $(TRUSTIFICATION_OIDC_CLIENT_SECRET)
+      # Set this password for your specific registry
+      # IMAGE_REGISTRY_PASSWORD: $(IMAGE_REGISTRY_PASSWORD)
+      # QUAY_IO_CREDS_PSW: $(QUAY_IO_CREDS_PSW)
+      # ARTIFACTORY_IO_CREDS_PSW: $(ARTIFACTORY_IO_CREDS_PSW)
+      # NEXUS_IO_CREDS_PSW: $(NEXUS_IO_CREDS_PSW)
+  - bash: |
+      echo "• gather-images-to-upload-sbom"
+      bash /work/rhtap/gather-images-to-upload-sbom.sh
+      echo "• download-sbom-from-url-in-attestation"
+      bash /work/rhtap/download-sbom-from-url-in-attestation.sh
+      echo "• upload-sbom-to-trustification"
+      bash /work/rhtap/upload-sbom-to-trustification.sh
+    name: Upload_sbom
+    env:
+      TRUSTIFICATION_OIDC_CLIENT_SECRET: $(TRUSTIFICATION_OIDC_CLIENT_SECRET)
+      # Set this password for your specific registry
+      # IMAGE_REGISTRY_PASSWORD: $(IMAGE_REGISTRY_PASSWORD)
+      # QUAY_IO_CREDS_PSW: $(QUAY_IO_CREDS_PSW)
+      # ARTIFACTORY_IO_CREDS_PSW: $(ARTIFACTORY_IO_CREDS_PSW)
+      # NEXUS_IO_CREDS_PSW: $(NEXUS_IO_CREDS_PSW)

--- a/skeleton/ci/gitops-template/azure/rhtap/env.sh
+++ b/skeleton/ci/gitops-template/azure/rhtap/env.sh
@@ -1,0 +1,55 @@
+# from init
+export REBUILD=${REBUILD-true}
+export SKIP_CHECKS=${SKIP_CHECKS-true}
+
+CI_TYPE=${CI_TYPE:-jenkins}
+
+# from buildah-rhtap
+TAG=$(git rev-parse HEAD)
+export IMAGE_URL=${IMAGE_URL-${{ values.image }}:$CI_TYPE-$TAG}
+export IMAGE=${IMAGE-$IMAGE_URL}
+
+export DOCKERFILE=${DOCKERFILE-${{ values.dockerfile }}}
+export CONTEXT=${CONTEXT-${{ values.buildContext }}}
+export TLSVERIFY=${TLSVERIFY-false}
+export BUILD_ARGS=${BUILD_ARGS-""}
+export BUILD_ARGS_FILE=${BUILD_ARGS_FILE-""}
+
+# from ACS_*.*
+export DISABLE_ACS=${DISABLE_ACS-false}
+# Optionally set ROX_CENTRAL_ENDPOINT here instead of configuring a Jenkins secret
+# export ROX_CENTRAL_ENDPOINT=central-acs.apps.user.cluster.domain.com:443
+export INSECURE_SKIP_TLS_VERIFY=${INSECURE_SKIP_TLS_VERIFY-true}
+
+# for gitops, if acs scans are set, we still may not want that repo
+# to be updates so include an option to disable
+
+export DISABLE_GITOPS_UPDATE=${DISABLE_GITOPS_UPDATE-false}
+export GITOPS_REPO_URL=${{ values.repoURL }}
+
+export PARAM_IMAGE=${PARAM_IMAGE-$IMAGE}
+# Recompute this every time, otherwise it will be set BEFORE the file exists
+# and be stuck at latest
+export PARAM_IMAGE_DIGEST=$(cat "$BASE_RESULTS/buildah-rhtap/IMAGE_DIGEST" 2>/dev/null || echo "latest")
+
+# From Summary
+export SOURCE_BUILD_RESULT_FILE=${SOURCE_BUILD_RESULT_FILE-""}
+
+# gather images params
+
+export TARGET_BRANCH=${TARGET_BRANCH-""}
+# enterprise contract
+export POLICY_CONFIGURATION=${POLICY_CONFIGURATION-"github.com/enterprise-contract/config//rhtap-v0.6"}
+#internal, assumes jenkins is local openshift
+export REKOR_HOST=${REKOR_HOST-http://rekor-server.rhtap-tas.svc}
+export IGNORE_REKOR=${IGNORE_REKOR-false}
+export INFO=${INFO-true}
+export STRICT=${STRICT-true}
+export EFFECTIVE_TIME=${EFFECTIVE_TIME-now}
+export HOMEDIR=${HOMEDIR-$(pwd)}
+export TUF_MIRROR=${TUF_MIRROR-http://tuf.rhtap-tas.svc}
+
+# Allow PR to succeed even if TAS vars not configured
+export FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED=false
+
+export SBOMS_DIR=results/sboms

--- a/skeleton/ci/source-repo/azure/azure-pipelines.yml
+++ b/skeleton/ci/source-repo/azure/azure-pipelines.yml
@@ -1,0 +1,91 @@
+# Generated from templates/source-repo/azure-pipelines.yml.njk. Do not edit directly.
+
+trigger:
+- main
+
+pool:
+  name: resourcehub
+
+container:
+  image: quay.io/redhat-appstudio/rhtap-task-runner:latest
+  options: --privileged
+
+steps:
+  - bash: |
+      echo "• init"
+      bash /work/rhtap/init.sh
+    name: Init
+    env:
+      ROX_API_TOKEN: $(ROX_API_TOKEN)
+      GITOPS_AUTH_PASSWORD: $(GITOPS_AUTH_PASSWORD)
+      # Set this password for your specific registry
+      IMAGE_REGISTRY_PASSWORD: $(IMAGE_REGISTRY_PASSWORD)
+      # QUAY_IO_CREDS_PSW: $(QUAY_IO_CREDS_PSW)
+      # ARTIFACTORY_IO_CREDS_PSW: $(ARTIFACTORY_IO_CREDS_PSW)
+      # NEXUS_IO_CREDS_PSW: $(NEXUS_IO_CREDS_PSW)
+      COSIGN_SECRET_PASSWORD: $(COSIGN_SECRET_PASSWORD)
+      COSIGN_SECRET_KEY: $(COSIGN_SECRET_KEY)
+  - bash: |
+      echo "• buildah-rhtap"
+      bash /work/rhtap/buildah-rhtap.sh
+      echo "• cosign-sign-attest"
+      bash /work/rhtap/cosign-sign-attest.sh
+    name: Build
+    env:
+      ROX_API_TOKEN: $(ROX_API_TOKEN)
+      GITOPS_AUTH_PASSWORD: $(GITOPS_AUTH_PASSWORD)
+      # Set this password for your specific registry
+      IMAGE_REGISTRY_PASSWORD: $(IMAGE_REGISTRY_PASSWORD)
+      # QUAY_IO_CREDS_PSW: $(QUAY_IO_CREDS_PSW)
+      # ARTIFACTORY_IO_CREDS_PSW: $(ARTIFACTORY_IO_CREDS_PSW)
+      # NEXUS_IO_CREDS_PSW: $(NEXUS_IO_CREDS_PSW)
+      COSIGN_SECRET_PASSWORD: $(COSIGN_SECRET_PASSWORD)
+      COSIGN_SECRET_KEY: $(COSIGN_SECRET_KEY)
+  - bash: |
+      echo "• update-deployment"
+      bash /work/rhtap/update-deployment.sh
+    name: Deploy
+    env:
+      ROX_API_TOKEN: $(ROX_API_TOKEN)
+      GITOPS_AUTH_PASSWORD: $(GITOPS_AUTH_PASSWORD)
+      # Set this password for your specific registry
+      IMAGE_REGISTRY_PASSWORD: $(IMAGE_REGISTRY_PASSWORD)
+      # QUAY_IO_CREDS_PSW: $(QUAY_IO_CREDS_PSW)
+      # ARTIFACTORY_IO_CREDS_PSW: $(ARTIFACTORY_IO_CREDS_PSW)
+      # NEXUS_IO_CREDS_PSW: $(NEXUS_IO_CREDS_PSW)
+      COSIGN_SECRET_PASSWORD: $(COSIGN_SECRET_PASSWORD)
+      COSIGN_SECRET_KEY: $(COSIGN_SECRET_KEY)
+  - bash: |
+      echo "• acs-deploy-check"
+      bash /work/rhtap/acs-deploy-check.sh
+      echo "• acs-image-check"
+      bash /work/rhtap/acs-image-check.sh
+      echo "• acs-image-scan"
+      bash /work/rhtap/acs-image-scan.sh
+    name: Scan
+    env:
+      ROX_API_TOKEN: $(ROX_API_TOKEN)
+      GITOPS_AUTH_PASSWORD: $(GITOPS_AUTH_PASSWORD)
+      # Set this password for your specific registry
+      IMAGE_REGISTRY_PASSWORD: $(IMAGE_REGISTRY_PASSWORD)
+      # QUAY_IO_CREDS_PSW: $(QUAY_IO_CREDS_PSW)
+      # ARTIFACTORY_IO_CREDS_PSW: $(ARTIFACTORY_IO_CREDS_PSW)
+      # NEXUS_IO_CREDS_PSW: $(NEXUS_IO_CREDS_PSW)
+      COSIGN_SECRET_PASSWORD: $(COSIGN_SECRET_PASSWORD)
+      COSIGN_SECRET_KEY: $(COSIGN_SECRET_KEY)
+  - bash: |
+      echo "• show-sbom-rhdh"
+      bash /work/rhtap/show-sbom-rhdh.sh
+      echo "• summary"
+      bash /work/rhtap/summary.sh
+    name: Summary
+    env:
+      ROX_API_TOKEN: $(ROX_API_TOKEN)
+      GITOPS_AUTH_PASSWORD: $(GITOPS_AUTH_PASSWORD)
+      # Set this password for your specific registry
+      IMAGE_REGISTRY_PASSWORD: $(IMAGE_REGISTRY_PASSWORD)
+      # QUAY_IO_CREDS_PSW: $(QUAY_IO_CREDS_PSW)
+      # ARTIFACTORY_IO_CREDS_PSW: $(ARTIFACTORY_IO_CREDS_PSW)
+      # NEXUS_IO_CREDS_PSW: $(NEXUS_IO_CREDS_PSW)
+      COSIGN_SECRET_PASSWORD: $(COSIGN_SECRET_PASSWORD)
+      COSIGN_SECRET_KEY: $(COSIGN_SECRET_KEY)

--- a/skeleton/ci/source-repo/azure/rhtap/env.sh
+++ b/skeleton/ci/source-repo/azure/rhtap/env.sh
@@ -1,0 +1,55 @@
+# from init
+export REBUILD=${REBUILD-true}
+export SKIP_CHECKS=${SKIP_CHECKS-true}
+
+CI_TYPE=${CI_TYPE:-jenkins}
+
+# from buildah-rhtap
+TAG=$(git rev-parse HEAD)
+export IMAGE_URL=${IMAGE_URL-${{ values.image }}:$CI_TYPE-$TAG}
+export IMAGE=${IMAGE-$IMAGE_URL}
+
+export DOCKERFILE=${DOCKERFILE-${{ values.dockerfile }}}
+export CONTEXT=${CONTEXT-${{ values.buildContext }}}
+export TLSVERIFY=${TLSVERIFY-false}
+export BUILD_ARGS=${BUILD_ARGS-""}
+export BUILD_ARGS_FILE=${BUILD_ARGS_FILE-""}
+
+# from ACS_*.*
+export DISABLE_ACS=${DISABLE_ACS-false}
+# Optionally set ROX_CENTRAL_ENDPOINT here instead of configuring a Jenkins secret
+# export ROX_CENTRAL_ENDPOINT=central-acs.apps.user.cluster.domain.com:443
+export INSECURE_SKIP_TLS_VERIFY=${INSECURE_SKIP_TLS_VERIFY-true}
+
+# for gitops, if acs scans are set, we still may not want that repo
+# to be updates so include an option to disable
+
+export DISABLE_GITOPS_UPDATE=${DISABLE_GITOPS_UPDATE-false}
+export GITOPS_REPO_URL=${{ values.repoURL }}
+
+export PARAM_IMAGE=${PARAM_IMAGE-$IMAGE}
+# Recompute this every time, otherwise it will be set BEFORE the file exists
+# and be stuck at latest
+export PARAM_IMAGE_DIGEST=$(cat "$BASE_RESULTS/buildah-rhtap/IMAGE_DIGEST" 2>/dev/null || echo "latest")
+
+# From Summary
+export SOURCE_BUILD_RESULT_FILE=${SOURCE_BUILD_RESULT_FILE-""}
+
+# gather images params
+
+export TARGET_BRANCH=${TARGET_BRANCH-""}
+# enterprise contract
+export POLICY_CONFIGURATION=${POLICY_CONFIGURATION-"github.com/enterprise-contract/config//rhtap-v0.6"}
+#internal, assumes jenkins is local openshift
+export REKOR_HOST=${REKOR_HOST-http://rekor-server.rhtap-tas.svc}
+export IGNORE_REKOR=${IGNORE_REKOR-false}
+export INFO=${INFO-true}
+export STRICT=${STRICT-true}
+export EFFECTIVE_TIME=${EFFECTIVE_TIME-now}
+export HOMEDIR=${HOMEDIR-$(pwd)}
+export TUF_MIRROR=${TUF_MIRROR-http://tuf.rhtap-tas.svc}
+
+# Allow PR to succeed even if TAS vars not configured
+export FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED=false
+
+export SBOMS_DIR=results/sboms


### PR DESCRIPTION
Sync the Azure Pipelines workflow definitions files to templates. Newly created repositories using Azure Pipelines as a CI provider will include a azure-pipelines.yml definition together with rhtap/env.sh