### PR TITLE
RHDHPAI-705: Model server gitops template & properties

### DIFF
--- a/all.yaml
+++ b/all.yaml
@@ -1,8 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: dance-all
-  description: Dance Language Samples
+  name: ai-all
+  description: AI Samples
 spec:
   targets:
     - ./templates/ai-sample-chatbot-dance/template.yaml  

--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -207,6 +207,9 @@ spec:
         - imageOrg
         - imageName
         - namespace
+        - modelServerEndpoint
+        - modelServerName
+        - includeModelEndpointSecret
       properties:
         imageRegistry:
           title: Image Registry
@@ -232,6 +235,39 @@ spec:
           ui:options:
             rows: 5
           ui:help: "This will be the prefix of the following three namespaces for deployment: <namespace>-development, <namespace>-stage, <namespace>-prod"
+        modelServerEndpoint:
+          title: Model Server Endpoint
+          type: string
+          ui:help: API URL for accessing a target AI model server
+        modelServerName:
+          title: Model Server Name
+          type: string
+          ui:help: Title of target AI model server
+        includeModelEndpointSecret:
+          title: Is bearer authentication required for Model Server?
+          type: boolean
+          default: false
+          ui:help: Create a Secret containing the authentication bearer in the preferred targeted Namespace first.
+      dependencies:
+        includeModelEndpointSecret:
+          allOf:
+            - if:
+                properties:
+                  includeModelEndpointSecret:
+                    const: true
+              then:
+                properties:
+                  modelEndpointSecretName:
+                    title: Model Server Endpoint Secret Name
+                    ui:help: Paste in the name of the Secret containing your bearer.
+                    type: string
+                  modelEndpointSecretKey:
+                    title: Model Server Endpoint Secret Key
+                    ui:help: Paste in the key of the Secret containing the bearer value.
+                    type: string
+                required:
+                  - modelEndpointSecretName
+                  - modelEndpointSecretKey
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
@@ -276,6 +312,11 @@ spec:
           secretRef: ${{ parameters.hostType != 'GitHub' }}
           isTekton: ${{ parameters.ciType === 'tekton' }}
           isJenkins: ${{ parameters.ciType === 'jenkins' }}
+          modelServerEndpoint: ${{ parameters.modelServerEndpoint }}
+          modelServerName: ${{ parameters.modelServerName }}
+          includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
+          modelEndpointSecretName: ${{ parameters.modelEndpointSecretName if parameters.includeModelEndpointSecret else '' }}
+          modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey if parameters.includeModelEndpointSecret else '' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: ${GIT__SECRET__DEFAULT__KEY}
           webhookSecret: ${WEBHOOK__SECRET__DEFAULT__NAME}

--- a/skeleton/gitops-template/components/http/base/deployment.yaml
+++ b/skeleton/gitops-template/components/http/base/deployment.yaml
@@ -46,8 +46,18 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi    
+        envFrom:
+        - configMapRef:
+            name: ${{ values.name }}-model-config
         env:
         - name: GIT_REPO
           value: ${{ values.repoURL }}
+        {%- if values.includeModelEndpointSecret %}
+        - name: MODEL_ENDPOINT_BEARER
+          valueFrom:
+            secretKeyRef:
+              name: ${{  values.modelEndpointSecretName  }}
+              key: ${{  values.modelEndpointSecretKey  }}
+        {%- endif %}
       imagePullSecrets:
         - name: rhtap-image-registry-auth

--- a/skeleton/gitops-template/components/http/base/kustomization.yaml
+++ b/skeleton/gitops-template/components/http/base/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - deployment.yaml
   - route.yaml
   - service.yaml
+  - model-config.yaml

--- a/skeleton/gitops-template/components/http/base/model-config.yaml
+++ b/skeleton/gitops-template/components/http/base/model-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ values.name }}-model-config
+data:
+  MODEL_ENDPOINT: "${{ values.modelServerEndpoint }}"
+  MODEL_NAME: "${{ values.modelServerName }}"

--- a/templates/ai-sample-chatbot-dance/template.yaml
+++ b/templates/ai-sample-chatbot-dance/template.yaml
@@ -207,6 +207,9 @@ spec:
         - imageOrg
         - imageName
         - namespace
+        - modelServerEndpoint
+        - modelServerName
+        - includeModelEndpointSecret
       properties:
         imageRegistry:
           title: Image Registry
@@ -232,6 +235,39 @@ spec:
           ui:options:
             rows: 5
           ui:help: "This will be the prefix of the following three namespaces for deployment: <namespace>-development, <namespace>-stage, <namespace>-prod"
+        modelServerEndpoint:
+          title: Model Server Endpoint
+          type: string
+          ui:help: API URL for accessing a target AI model server
+        modelServerName:
+          title: Model Server Name
+          type: string
+          ui:help: Title of target AI model server
+        includeModelEndpointSecret:
+          title: Is bearer authentication required for Model Server?
+          type: boolean
+          default: false
+          ui:help: Create a Secret containing the authentication bearer in the preferred targeted Namespace first.
+      dependencies:
+        includeModelEndpointSecret:
+          allOf:
+            - if:
+                properties:
+                  includeModelEndpointSecret:
+                    const: true
+              then:
+                properties:
+                  modelEndpointSecretName:
+                    title: Model Server Endpoint Secret Name
+                    ui:help: Paste in the name of the Secret containing your bearer.
+                    type: string
+                  modelEndpointSecretKey:
+                    title: Model Server Endpoint Secret Key
+                    ui:help: Paste in the key of the Secret containing the bearer value.
+                    type: string
+                required:
+                  - modelEndpointSecretName
+                  - modelEndpointSecretKey
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
@@ -276,6 +312,11 @@ spec:
           secretRef: ${{ parameters.hostType != 'GitHub' }}
           isTekton: ${{ parameters.ciType === 'tekton' }}
           isJenkins: ${{ parameters.ciType === 'jenkins' }}
+          modelServerEndpoint: ${{ parameters.modelServerEndpoint }}
+          modelServerName: ${{ parameters.modelServerName }}
+          includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
+          modelEndpointSecretName: ${{ parameters.modelEndpointSecretName if parameters.includeModelEndpointSecret else '' }}
+          modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey if parameters.includeModelEndpointSecret else '' }}
           gitSecret: ${{ 'gitops-auth-secret' if parameters.hostType === 'GitHub' else ('gitlab-auth-secret' if parameters.hostType === 'GitLab' else 'bitbucket-auth-secret')}}
           gitSecretKey: password
           webhookSecret: pipelines-secret


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHDHPAI-705

## Model server properties

Adds properties to the 'Deployment Information' page to prompt user for model server information to the Software Template skeleton and Chatbot Software Template under `ai-samples` branch, these properties include:
- Model Server Endpoint
- Model Server Name
- Does Model Server Require a Bearer token?
- *Bearer Token Secret Name
- *Bearer Token Secret Key Name

**\*Only required if 'Does Model Server Require a Bearer token?' is set, unset by default**

## Model server config

Adds model server config resources and mappings to GitOps deployment template for `ai-samples` branch, this is needed to connect a model server to an AI application created from the AI Software Templates.

## Rename template catalog

Renames the templates catalog for the `ai-samples` branch to `ai-all` to differ from `main` branch catalog name.

