### PR TITLE
fix: remove gitops repo copy from source repo

### DIFF
--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -406,6 +406,7 @@ spec:
       name: Fetch Base
       action: fetch:template
       input:
+        targetPath: source
         url: ./content
         values:
           name: ${{ parameters.name }}
@@ -417,6 +418,7 @@ spec:
       name: Fetch Source Skeleton
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/source-repo
         values:
           name: ${{ parameters.name }}
@@ -443,6 +445,7 @@ spec:
       name: Fetch Source CI
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
@@ -476,6 +479,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab-source
       name: Publish Repository to GitLab
@@ -488,6 +492,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new Bitbucket Cloud repository and publishes the files in the workspace directory to the repository.
     - id: publish-bitbucket-source
       name: Publish Repository to Bitbucket
@@ -500,6 +505,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
 
     #
     # Register objects in Backstage

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -406,6 +406,7 @@ spec:
       name: Fetch Base
       action: fetch:template
       input:
+        targetPath: source
         url: ./content
         values:
           name: ${{ parameters.name }}
@@ -417,6 +418,7 @@ spec:
       name: Fetch Source Skeleton
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/source-repo
         values:
           name: ${{ parameters.name }}
@@ -443,6 +445,7 @@ spec:
       name: Fetch Source CI
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
@@ -476,6 +479,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab-source
       name: Publish Repository to GitLab
@@ -488,6 +492,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new Bitbucket Cloud repository and publishes the files in the workspace directory to the repository.
     - id: publish-bitbucket-source
       name: Publish Repository to Bitbucket
@@ -500,6 +505,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
 
     #
     # Register objects in Backstage

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -406,6 +406,7 @@ spec:
       name: Fetch Base
       action: fetch:template
       input:
+        targetPath: source
         url: ./content
         values:
           name: ${{ parameters.name }}
@@ -417,6 +418,7 @@ spec:
       name: Fetch Source Skeleton
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/source-repo
         values:
           name: ${{ parameters.name }}
@@ -443,6 +445,7 @@ spec:
       name: Fetch Source CI
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
@@ -476,6 +479,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab-source
       name: Publish Repository to GitLab
@@ -488,6 +492,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new Bitbucket Cloud repository and publishes the files in the workspace directory to the repository.
     - id: publish-bitbucket-source
       name: Publish Repository to Bitbucket
@@ -500,6 +505,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
 
     #
     # Register objects in Backstage

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -406,6 +406,7 @@ spec:
       name: Fetch Base
       action: fetch:template
       input:
+        targetPath: source
         url: ./content
         values:
           name: ${{ parameters.name }}
@@ -417,6 +418,7 @@ spec:
       name: Fetch Source Skeleton
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/source-repo
         values:
           name: ${{ parameters.name }}
@@ -443,6 +445,7 @@ spec:
       name: Fetch Source CI
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
@@ -476,6 +479,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab-source
       name: Publish Repository to GitLab
@@ -488,6 +492,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new Bitbucket Cloud repository and publishes the files in the workspace directory to the repository.
     - id: publish-bitbucket-source
       name: Publish Repository to Bitbucket
@@ -500,6 +505,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
 
     #
     # Register objects in Backstage

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -406,6 +406,7 @@ spec:
       name: Fetch Base
       action: fetch:template
       input:
+        targetPath: source
         url: ./content
         values:
           name: ${{ parameters.name }}
@@ -417,6 +418,7 @@ spec:
       name: Fetch Source Skeleton
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/source-repo
         values:
           name: ${{ parameters.name }}
@@ -443,6 +445,7 @@ spec:
       name: Fetch Source CI
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
@@ -476,6 +479,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab-source
       name: Publish Repository to GitLab
@@ -488,6 +492,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new Bitbucket Cloud repository and publishes the files in the workspace directory to the repository.
     - id: publish-bitbucket-source
       name: Publish Repository to Bitbucket
@@ -500,6 +505,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
 
     #
     # Register objects in Backstage

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -406,6 +406,7 @@ spec:
       name: Fetch Base
       action: fetch:template
       input:
+        targetPath: source
         url: ./content
         values:
           name: ${{ parameters.name }}
@@ -417,6 +418,7 @@ spec:
       name: Fetch Source Skeleton
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/source-repo
         values:
           name: ${{ parameters.name }}
@@ -443,6 +445,7 @@ spec:
       name: Fetch Source CI
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
@@ -476,6 +479,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab-source
       name: Publish Repository to GitLab
@@ -488,6 +492,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new Bitbucket Cloud repository and publishes the files in the workspace directory to the repository.
     - id: publish-bitbucket-source
       name: Publish Repository to Bitbucket
@@ -500,6 +505,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
 
     #
     # Register objects in Backstage

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -406,6 +406,7 @@ spec:
       name: Fetch Base
       action: fetch:template
       input:
+        targetPath: source
         url: ./content
         values:
           name: ${{ parameters.name }}
@@ -417,6 +418,7 @@ spec:
       name: Fetch Source Skeleton
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/source-repo
         values:
           name: ${{ parameters.name }}
@@ -443,6 +445,7 @@ spec:
       name: Fetch Source CI
       action: fetch:template
       input:
+        targetPath: source
         url: ../../skeleton/ci/source-repo/${{ parameters.ciType}}
         copyWithoutRender:
           - .github/workflows/*
@@ -476,6 +479,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new GitLab repository and publishes the files in the workspace directory to the repository.
     - id: publish-gitlab-source
       name: Publish Repository to GitLab
@@ -488,6 +492,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
     # This action creates a new Bitbucket Cloud repository and publishes the files in the workspace directory to the repository.
     - id: publish-bitbucket-source
       name: Publish Repository to Bitbucket
@@ -500,6 +505,7 @@ spec:
         defaultBranch: ${{ parameters.branch }}
         protectDefaultBranch: false
         repoVisibility: "public"
+        sourcePath: source
 
     #
     # Register objects in Backstage


### PR DESCRIPTION
This bug was introduced with 793d7c35969e1354d0bb3fe44d511733a597bf1c

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED