### PR TITLE
Use release branch for Jenkins library

### DIFF
--- a/skeleton/ci/gitops-template/jenkins/Jenkinsfile
+++ b/skeleton/ci/gitops-template/jenkins/Jenkinsfile
@@ -1,6 +1,6 @@
 /* Generated from templates/gitops-template/Jenkinsfile.njk. Do not edit directly. */
 
-library identifier: 'RHTAP_Jenkins@v1.6', retriever: modernSCM(
+library identifier: 'RHTAP_Jenkins@release-v1.6.x', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: 'https://github.com/redhat-appstudio/tssc-sample-jenkins.git'])
 

--- a/skeleton/ci/source-repo/jenkins/Jenkinsfile
+++ b/skeleton/ci/source-repo/jenkins/Jenkinsfile
@@ -1,6 +1,6 @@
 /* Generated from templates/source-repo/Jenkinsfile.njk. Do not edit directly. */
 
-library identifier: 'RHTAP_Jenkins@v1.6', retriever: modernSCM(
+library identifier: 'RHTAP_Jenkins@release-v1.6.x', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: 'https://github.com/redhat-appstudio/tssc-sample-jenkins.git'])
 


### PR DESCRIPTION
Modify the Jenkinsfiles so the Jenkins library is referenced by a branch instead of a tag. This facilitates pushing bug fixes to users.