### PR TITLE
Rename Backstage Location to tssc-all

### DIFF
--- a/all.yaml
+++ b/all.yaml
@@ -1,8 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: dance-all
-  description: Dance Language Samples
+  name: tssc-all
+  description: TSSC Application Samples
 spec:
   targets:
     - ./templates/dotnet/template.yaml


### PR DESCRIPTION
The previous name, dance-all, refers to an old code name of the project that is no longer used nor meaningful. Instead, use the TSSC terminology which has been used widely in various repositories.
