### PR TITLE
Add RFC 1123 validation to component name fields

### DIFF
--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -25,6 +25,8 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          ui:help: "Lowercase letters, digits, and hyphens; must start/end with alphanumeric (RFC 1123). Example: my-service-1"
         owner:
           title: Owner
           type: string

--- a/templates/dotnet/template.yaml
+++ b/templates/dotnet/template.yaml
@@ -25,6 +25,8 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          ui:help: "Lowercase letters, digits, and hyphens; must start/end with alphanumeric (RFC 1123). Example: my-service-1"
         owner:
           title: Owner
           type: string

--- a/templates/generic-import-from-repo/template.yaml
+++ b/templates/generic-import-from-repo/template.yaml
@@ -31,6 +31,8 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          ui:help: "Lowercase letters, digits, and hyphens; must start/end with alphanumeric (RFC 1123). Example: my-service-1"
         owner:
           title: Owner
           type: string

--- a/templates/go/template.yaml
+++ b/templates/go/template.yaml
@@ -25,6 +25,8 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          ui:help: "Lowercase letters, digits, and hyphens; must start/end with alphanumeric (RFC 1123). Example: my-service-1"
         owner:
           title: Owner
           type: string

--- a/templates/java-quarkus/template.yaml
+++ b/templates/java-quarkus/template.yaml
@@ -25,6 +25,8 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          ui:help: "Lowercase letters, digits, and hyphens; must start/end with alphanumeric (RFC 1123). Example: my-service-1"
         owner:
           title: Owner
           type: string

--- a/templates/java-springboot/template.yaml
+++ b/templates/java-springboot/template.yaml
@@ -25,6 +25,8 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          ui:help: "Lowercase letters, digits, and hyphens; must start/end with alphanumeric (RFC 1123). Example: my-service-1"
         owner:
           title: Owner
           type: string

--- a/templates/nodejs/template.yaml
+++ b/templates/nodejs/template.yaml
@@ -25,6 +25,8 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          ui:help: "Lowercase letters, digits, and hyphens; must start/end with alphanumeric (RFC 1123). Example: my-service-1"
         owner:
           title: Owner
           type: string

--- a/templates/python/template.yaml
+++ b/templates/python/template.yaml
@@ -25,6 +25,8 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          ui:help: "Lowercase letters, digits, and hyphens; must start/end with alphanumeric (RFC 1123). Example: my-service-1"
         owner:
           title: Owner
           type: string


### PR DESCRIPTION
Add pattern validation to ensure component names are lowercase alphanumeric with hyphens
Prevents ArgoCD creation failures from invalid metadata.name values
Includes custom error messages with examples for better user experience
Fixes validation for all template files: Python, Go, Quarkus, Java, .NET, Node.js
Pattern: ^[a-z0-9](https://github.com/rhopp/tssc-sample-templates/pull/%5B-a-z0-9%5D*%5Ba-z0-9%5D)?$
Resolves component creation failures with uppercase/special characters

Addresses: https://issues.redhat.com/browse/RHTAP-5259