### PR TITLE
feat: cancel Tekton PipelineRuns on PR updates

### DIFF
--- a/skeleton/ci/gitops-template/tekton/.tekton/gitops-on-pull-request.yaml
+++ b/skeleton/ci/gitops-template/tekton/.tekton/gitops-on-pull-request.yaml
@@ -3,6 +3,7 @@ kind: PipelineRun
 metadata:
   name: ${{ values.name }}-gitops-on-pull-request
   annotations:
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[${{ values.defaultBranch }}]"
     pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/redhat-appstudio/tssc-sample-pipelines/main/pac/pipelines/gitops-pull-request-rhtap.yaml"

--- a/skeleton/ci/source-repo/tekton/.tekton/docker-pull-request.yaml
+++ b/skeleton/ci/source-repo/tekton/.tekton/docker-pull-request.yaml
@@ -3,6 +3,7 @@ kind: PipelineRun
 metadata:
   name: ${{ values.name }}-on-pull-request
   annotations:
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[${{ values.defaultBranch }}]"
     pipelinesascode.tekton.dev/max-keep-runs: "2"

--- a/skeleton/ci/source-repo/tekton/.tekton/docker-push.yaml
+++ b/skeleton/ci/source-repo/tekton/.tekton/docker-push.yaml
@@ -3,6 +3,7 @@ kind: PipelineRun
 metadata:
   name: ${{ values.name }}-on-push
   annotations:
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[${{ values.defaultBranch }}]"
     pipelinesascode.tekton.dev/max-keep-runs: "2"


### PR DESCRIPTION
## Description

When a pull request is updated with new commits, any currently running PipelineRuns for that PR should be cancelled to avoid redundant work.

The setting is kept to false on merge, as it would prevent the release of multiple commits pushed in a short time frame.

cf RHTAP-4563

## Testing Instructions

N/A.
